### PR TITLE
feat(Exception): Return request errors with index for batch request

### DIFF
--- a/CSharp/src/BusinessApp.App.UnitTest/CompositeValidatorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/CompositeValidatorTests.cs
@@ -1,0 +1,110 @@
+namespace BusinessApp.App.UnitTests
+{
+    using System;
+    using Xunit;
+    using System.Collections.Generic;
+    using FakeItEasy;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using BusinessApp.Domain;
+
+    public class ValidationStub {  }
+
+    public class CompositeValidatorTests
+    {
+        private readonly IEnumerable<IValidator<ValidationStub>> validators;
+        private readonly ValidationStub instance;
+        private CompositeValidator<ValidationStub> sut;
+
+        public CompositeValidatorTests()
+        {
+            instance = new ValidationStub();
+            validators = new[]
+            {
+                A.Fake<IValidator<ValidationStub>>(),
+                A.Fake<IValidator<ValidationStub>>(),
+            };
+            sut = new CompositeValidator<ValidationStub>(validators);
+        }
+
+        [Fact]
+        public void Constructor_ExceptionThrown()
+        {
+            /* Arrange */
+            void shouldThrow() => new CompositeValidator<ValidationStub>(null);
+
+            /* Act */
+            var ex = Record.Exception(shouldThrow);
+
+            /* Assert */
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Fact]
+        public async Task ValidateObject_NoValidators_NoExceptionThrown()
+        {
+            /* Arrange */
+            sut = new CompositeValidator<ValidationStub>(new IValidator<ValidationStub>[0]);
+            async Task shouldNotThrow() => await sut.ValidateAsync(A.Dummy<ValidationStub>());
+
+            /* Act */
+            var ex = await Record.ExceptionAsync(shouldNotThrow);
+
+            /* Assert */
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task ValidateObject_HasOneError_ValidationExceptionThrown()
+        {
+            /* Arrange */
+            var expectedEx = new ValidationException("foo");
+            A.CallTo(() => validators.First().ValidateAsync(instance))
+                .Throws(expectedEx);
+            async Task shouldThrow() => await sut.ValidateAsync(instance);
+
+            /* Act */
+            var actualEx = await Record.ExceptionAsync(shouldThrow);
+
+            /* Assert */
+            Assert.Same(expectedEx, actualEx);
+        }
+
+        [Fact]
+        public async Task ValidateObject_HasManyErrors_AggregateExceptionThrown()
+        {
+            /* Arrange */
+            A.CallTo(() => validators.First().ValidateAsync(instance))
+                .Throws(new ValidationException("foo"));
+            A.CallTo(() => validators.Last().ValidateAsync(instance))
+                .Throws(new ValidationException("bar"));
+            async Task shouldThrow() => await sut.ValidateAsync(instance);
+
+            /* Act */
+            var actualEx = await Record.ExceptionAsync(shouldThrow);
+
+            /* Assert */
+            Assert.IsType<AggregateException>(actualEx);
+        }
+
+        [Fact]
+        public async Task ValidateObject_HasManyErrors_ContainsInnerValidationExceptions()
+        {
+            /* Arrange */
+            var firstEx = new ValidationException("foo");
+            var lastEx = new ValidationException("bar");
+            A.CallTo(() => validators.First().ValidateAsync(instance))
+                .Throws(firstEx);
+            A.CallTo(() => validators.Last().ValidateAsync(instance))
+                .Throws(lastEx);
+            async Task shouldThrow() => await sut.ValidateAsync(instance);
+
+            /* Act */
+            var actualEx = await Record.ExceptionAsync(shouldThrow) as AggregateException;
+
+            /* Assert */
+            Assert.Contains(firstEx, actualEx.Flatten().InnerExceptions);
+            Assert.Contains(lastEx, actualEx.Flatten().InnerExceptions);
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.App.UnitTest/DataAnnotationsValidatorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/DataAnnotationsValidatorTests.cs
@@ -1,0 +1,101 @@
+namespace BusinessApp.App.UnitTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Xunit;
+    using BusinessApp.Domain;
+
+    public class DataAnnotationsValidatorTests
+    {
+        private readonly IValidator<DataAnnotatedCommandStub> sut;
+
+        public DataAnnotationsValidatorTests()
+        {
+            sut = new DataAnnotationsValidator<DataAnnotatedCommandStub>();
+        }
+
+        public class ValidateObject_WithOneError : DataAnnotationsValidatorTests
+        {
+            [Fact]
+            public async Task ValidationExceptionThrown()
+            {
+                /* Arrange */
+                var instance = new DataAnnotatedCommandStub { Foo = new string('a', 11) };
+
+                /* Act */
+                var ex = await Record.ExceptionAsync(async () => await sut.ValidateAsync(instance));
+
+                /* Assert */
+                Assert.IsType<ValidationException>(ex);
+                Assert.Equal("The field Foo must be a string with a maximum length of 10.", ex.Message);
+            }
+        }
+
+        public class ValidateObject_WithNoError : DataAnnotationsValidatorTests
+        {
+            [Fact]
+            public async Task NoExceptionThrown()
+            {
+                /* Arrange */
+                var instance = new DataAnnotatedCommandStub { Foo = new string('a', 10) };
+
+                /* Act */
+                var ex = await Record.ExceptionAsync(async () => await sut.ValidateAsync(instance));
+
+                /* Assert */
+                Assert.Null(ex);
+            }
+        }
+
+        public class ValidateObject_WithMultipleErrors : DataAnnotationsValidatorTests
+        {
+            DataAnnotatedCommandStub instance;
+
+            public ValidateObject_WithMultipleErrors()
+            {
+                instance = new DataAnnotatedCommandStub { Bar = null, Foo = new string('a', 11) };
+            }
+
+            [Fact]
+            public async Task AggregateExceptionThrown()
+            {
+                /* Act */
+                var ex = await Record.ExceptionAsync(async () => await sut.ValidateAsync(instance));
+
+                /* Assert */
+                Assert.IsType<AggregateException>(ex);
+            }
+
+            [Fact]
+            public async Task ContainsLenghtInnerValidationException()
+            {
+                /* Arrange */
+                var instance = new DataAnnotatedCommandStub { Bar = null, Foo = new string('a', 11) };
+
+                /* Act */
+                var ex = await Record.ExceptionAsync(async () => await sut.ValidateAsync(instance)) as AggregateException;
+
+                /* Assert */
+                Assert.Equal(
+                    "The field Foo must be a string with a maximum length of 10.",
+                    ex.Flatten().InnerExceptions.First().Message);
+            }
+
+            [Fact]
+            public async Task ContainsRequiredInnerValidationException()
+            {
+                /* Arrange */
+                var instance = new DataAnnotatedCommandStub { Bar = null, Foo = new string('a', 11) };
+
+                /* Act */
+                var ex = await Record.ExceptionAsync(async () => await sut.ValidateAsync(instance)) as AggregateException;
+
+                /* Assert */
+                Assert.Equal(
+                    "The Bar field is required.",
+                    ex.Flatten().InnerExceptions.Last().Message);
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.App.UnitTest/Dummies.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/Dummies.cs
@@ -1,4 +1,16 @@
 namespace BusinessApp.App.UnitTests
 {
+    using System.ComponentModel.DataAnnotations;
+
     public class DummyCommand { }
+
+    public class DataAnnotatedCommandStub
+    {
+        [StringLength(10)]
+        public string Foo { get; set; }
+
+        [Required]
+        public string Bar { get; set; } = "lorem";
+    }
+
 }

--- a/CSharp/src/BusinessApp.App.UnitTest/SecurityResourceExceptionTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/SecurityResourceExceptionTests.cs
@@ -1,4 +1,4 @@
-namespace BusinessApp.Domain.UnitTest
+namespace BusinessApp.App.UnitTest
 {
     using System;
     using Xunit;

--- a/CSharp/src/BusinessApp.App.UnitTest/SecurityResourceExceptionTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/SecurityResourceExceptionTests.cs
@@ -1,0 +1,69 @@
+namespace BusinessApp.Domain.UnitTest
+{
+    using System;
+    using Xunit;
+    using BusinessApp.App;
+    using BusinessApp.Domain;
+    using System.Linq;
+    using System.Collections.Generic;
+
+    public class SecurityResourceExceptionTests
+    {
+        public class Constructor : SecurityResourceExceptionTests
+        {
+            [Fact]
+            public void WithoutResourceName_Throws()
+            {
+                /* Arrange */
+                void shouldThrow() => new SecurityResourceException(null, "foo");
+
+                /* Act */
+                var ex = Record.Exception(shouldThrow);
+
+                /* Assert */
+                Assert.NotNull(ex);
+            }
+
+            [Fact]
+            public void WithResourceName_SetsResourceName()
+            {
+                /* Act */
+                var ex = new SecurityResourceException("foo", "bar");
+
+                /* Assert */
+                Assert.Equal("foo", ex.ResourceName);
+            }
+
+            [Fact]
+            public void WithResourceName_SetsData()
+            {
+                /* Act */
+                var ex = new SecurityResourceException("foo", "bar");
+
+                /* Assert */
+                var dictionary = Assert.IsType<Dictionary<string, string>>(ex.Data);
+                var data = Assert.Single(dictionary);
+                Assert.Contains("foo", data.Key);
+                Assert.Contains("bar", data.Value);
+            }
+        }
+
+        [Fact]
+        public void InnerExceptions_HasSome_Returned()
+        {
+            /* Arrange */
+            var innerInner = new Exception();
+            var inner = new Exception("foo", innerInner);
+            var ex = new Exception("bar", inner);
+
+            /* Act */
+            var inners = ex.InnerExceptions();
+
+            /* Assert */
+            Assert.Equal(2, inners.Count());
+            Assert.Contains(inner, inners);
+            Assert.Contains(inner, inners);
+        }
+    }
+}
+

--- a/CSharp/src/BusinessApp.App.UnitTest/ValidationCommandDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/ValidationCommandDecoratorTests.cs
@@ -68,7 +68,7 @@ namespace BusinessApp.App.UnitTests
                 /* Arrange */
                 var handlerCallsBeforeValidate = 0;
                 var command = A.Dummy<DummyCommand>();
-                A.CallTo(() => validator.ValidateObject(A<DummyCommand>._))
+                A.CallTo(() => validator.ValidateAsync(A<DummyCommand>._))
                     .Invokes(ctx => handlerCallsBeforeValidate += Fake.GetCalls(inner).Count());
 
                 /* Act */
@@ -88,7 +88,7 @@ namespace BusinessApp.App.UnitTests
                 await sut.HandleAsync(command, A.Dummy<CancellationToken>());
 
                 /* Assert */
-                A.CallTo(() => validator.ValidateObject(command))
+                A.CallTo(() => validator.ValidateAsync(command))
                     .MustHaveHappenedOnceExactly();
             }
 

--- a/CSharp/src/BusinessApp.App/DataAnnotationsValidator.cs
+++ b/CSharp/src/BusinessApp.App/DataAnnotationsValidator.cs
@@ -1,16 +1,19 @@
-﻿namespace BusinessApp.App
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace BusinessApp.App
 {
+    using System;
     using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
-    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using BusinessApp.Domain;
 
     /// <summary>
     /// Runs validations for data annotations
     /// </summary>
     public class DataAnnotationsValidator<TCommand> : IValidator<TCommand>
     {
-        [DebuggerStepThrough]
-        void IValidator<TCommand>.ValidateObject(TCommand instance)
+        Task IValidator<TCommand>.ValidateAsync(TCommand instance)
         {
             var context = new ValidationContext(instance);
             var errors = new List<ValidationResult>();
@@ -18,10 +21,17 @@
 
             if (!isValid)
             {
-                throw new ValidationException(
-                    new CompositeValidationResult("Multiple validation errors occurred", errors)
-                );
+                if (errors.Count == 1)
+                {
+                    throw new ValidationException(errors[0]);
+                }
+                else
+                {
+                    throw new AggregateException(errors.Select(e => new ValidationException(e)));
+                }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/CSharp/src/BusinessApp.App/FluentValidationValidator.cs
+++ b/CSharp/src/BusinessApp.App/FluentValidationValidator.cs
@@ -3,6 +3,7 @@ namespace BusinessApp.App
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
+    using System.Threading.Tasks;
     using BusinessApp.Domain;
 
     /// <summary>
@@ -17,13 +18,13 @@ namespace BusinessApp.App
             this.validators = GuardAgainst.Null(validators, nameof(validators));
         }
 
-        public void ValidateObject(TCommand instance)
+        public async Task ValidateAsync(TCommand instance)
         {
             var errors = new List<ValidationResult>();
 
             foreach (var validator in validators)
             {
-                var result = validator.Validate(instance);
+                var result = await validator.ValidateAsync(instance);
 
                 if (!result.IsValid)
                 {

--- a/CSharp/src/BusinessApp.App/IValidator.cs
+++ b/CSharp/src/BusinessApp.App/IValidator.cs
@@ -1,6 +1,7 @@
 ﻿namespace BusinessApp.App
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Interface to validate the data from an instance <typeparam name="T">T</typeparam>
@@ -11,6 +12,6 @@
         /// <param name="instance">The instance to validate.</param>
         /// <exception cref="ArgumentNullException">Thrown when the instance is a null reference.</exception>
         /// <exception cref="ValidationException">Thrown when the instance is invalid.</exception>
-        void ValidateObject(T instance);
+        Task ValidateAsync(T instance);
     }
 }

--- a/CSharp/src/BusinessApp.App/SecurityResourceException.cs
+++ b/CSharp/src/BusinessApp.App/SecurityResourceException.cs
@@ -1,0 +1,27 @@
+namespace BusinessApp.App
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Security;
+    using BusinessApp.Domain;
+
+    public class SecurityResourceException : SecurityException
+    {
+        public SecurityResourceException(string resourceName, string message, Exception inner = null)
+            :base(message, inner)
+        {
+            ResourceName = GuardAgainst.Empty(resourceName, nameof(resourceName));
+        }
+
+        public string ResourceName { get; }
+
+        public override IDictionary Data
+        {
+            get => new Dictionary<string, string>
+            {
+                { ResourceName, Message }
+            };
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.App/StringExtensions.cs
+++ b/CSharp/src/BusinessApp.App/StringExtensions.cs
@@ -1,0 +1,10 @@
+namespace BusinessApp.App
+{
+    public static class StringExtensions
+    {
+        public static string CreateIndexName(this string s, int index)
+        {
+            return $"[{index}].{s}";
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.App/ValidationCommandDecorator.cs
+++ b/CSharp/src/BusinessApp.App/ValidationCommandDecorator.cs
@@ -22,7 +22,7 @@
         {
             GuardAgainst.Null(command, nameof(command));
 
-            validator.ValidateObject(command);
+            validator.ValidateAsync(command);
 
             return handler.HandleAsync(command, cancellationToken);
         }

--- a/CSharp/src/BusinessApp.App/ValidationException.cs
+++ b/CSharp/src/BusinessApp.App/ValidationException.cs
@@ -4,6 +4,7 @@
     using System.Collections;
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
+    using BusinessApp.Domain;
 
     /// <summary>
     /// Aggregates all validations results into one exception

--- a/CSharp/src/BusinessApp.App/ValidationException.cs
+++ b/CSharp/src/BusinessApp.App/ValidationException.cs
@@ -1,11 +1,9 @@
-﻿namespace BusinessApp.App
+﻿namespace BusinessApp.Domain
 {
     using System;
     using System.Collections;
-    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
-    using BusinessApp.Domain;
 
     /// <summary>
     /// Aggregates all validations results into one exception
@@ -13,33 +11,36 @@
     [Serializable]
     public class ValidationException : Exception
     {
-        public ValidationException(IEnumerable<ValidationResult> results)
-            :base("Multiple Validation Errors Occurred. Please see the inner errors for more details")
+        public ValidationException(ValidationResult result, Exception inner = null)
+            :base(result.ErrorMessage, inner)
         {
-            Results = GuardAgainst.Null(results, nameof(results));
+            Result = GuardAgainst.Null(result, nameof(result));
+        }
+
+        public ValidationException(string memberName, string message, Exception inner = null)
+            :base(message, inner)
+        {
+            Result = new ValidationResult(message, new[] { memberName });
         }
 
         public ValidationException(string message)
             :base(message)
         {
-            Results = new[] { new ValidationResult(message) };
+            Result = new ValidationResult(message, new[] { "" });
         }
 
-        public IEnumerable<ValidationResult> Results { get; }
+        public ValidationResult Result { get; }
 
         /// <summary>
-        /// Converts the <see cref="Results"/> into a key, value pair
-        /// of property name and validation messages, rather than one message and many
-        /// member names.
+        /// Converts the <see cref="Result"/> into a key, value pair
+        /// of property name and validation messages
         /// </summary>
         public override IDictionary Data
         {
-            get => Results.SelectMany(r => r.MemberNames)
+            get => Result.MemberNames
                 .ToDictionary(
                     member => member,
-                    member => Results
-                        .Where(r => r.MemberNames.Contains(member))
-                        .Select(r => r.ErrorMessage));
+                    member => Result.ErrorMessage);
         }
     }
 }

--- a/CSharp/src/BusinessApp.App/ValidationException.cs
+++ b/CSharp/src/BusinessApp.App/ValidationException.cs
@@ -1,4 +1,4 @@
-﻿namespace BusinessApp.Domain
+﻿namespace BusinessApp.App
 {
     using System;
     using System.Collections;

--- a/CSharp/src/BusinessApp.App/ValidationResultExtensions.cs
+++ b/CSharp/src/BusinessApp.App/ValidationResultExtensions.cs
@@ -1,0 +1,22 @@
+namespace BusinessApp.App
+{
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+
+    public static class ValidationResultExtensions
+    {
+        public static ValidationResult CreateWithIndexName(this ValidationResult result, int index)
+        {
+            if (result.MemberNames.Where(m => !string.IsNullOrWhiteSpace(m)).Any())
+            {
+                var indexMemberNames = result.MemberNames
+                    .Select(n => n.CreateIndexName(index))
+                    .ToList();
+
+                return new ValidationResult(result.ErrorMessage, indexMemberNames);
+            }
+
+            return result;
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/BusinessApp.WebApi.UnitTest.csproj
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/BusinessApp.WebApi.UnitTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BusinessApp.WebApi\BusinessApp.WebApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ClaimsIdentityFakeFactory.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ClaimsIdentityFakeFactory.cs
@@ -1,0 +1,15 @@
+namespace BusinessApp.WebApi.UnitTest
+{
+  using System.Security.Claims;
+  using FakeItEasy;
+
+  public static class ClaimsIdentityFakeFactory
+  {
+    public static ClaimsIdentity New(string userName = "anyone")
+    {
+      var fakeId = A.Fake<ClaimsIdentity>();
+      A.CallTo(() => fakeId.Name).Returns(userName);
+      return fakeId;
+    }
+  }
+}

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ClaimsPrincipalFakeFactory.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ClaimsPrincipalFakeFactory.cs
@@ -1,0 +1,22 @@
+namespace BusinessApp.WebApi.UnitTest
+{
+  using System.Security.Claims;
+  using FakeItEasy;
+
+  public static class ClaimsPrincipalFakeFactory
+  {
+    public static ClaimsPrincipal New(ClaimsIdentity identity = null)
+    {
+      var fakeCp = A.Fake<ClaimsPrincipal>();
+
+      if (identity == null)
+      {
+        identity = ClaimsIdentityFakeFactory.New();
+      }
+
+      A.CallTo(() => fakeCp.Identity).Returns(identity);
+
+      return fakeCp;
+    }
+  }
+}

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ExceptionExtensionsTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ExceptionExtensionsTests.cs
@@ -1,0 +1,813 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BusinessApp.WebApi.UnitTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Security;
+    using System.Threading.Tasks;
+    using FakeItEasy;
+    using Microsoft.AspNetCore.Http;
+    using BusinessApp.App;
+    using BusinessApp.Domain;
+    using SimpleInjector;
+    using Xunit;
+
+    public class ExceptionExtensionsTests
+    {
+        private HttpContext http;
+
+        public ExceptionExtensionsTests()
+        {
+            http = HttpContextFakeFactory.New();
+        }
+
+        public class OnValidationException : ExceptionExtensionsTests
+        {
+            private readonly ValidationException ex;
+
+            public OnValidationException()
+            {
+                ex = new ValidationException("foo", "bar");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToBadResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(400)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToInvalidData()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/invalid-data", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal(
+                    "Your data was not accepted because it is not valid. Please fix the errors",
+                    response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("Invalid Data", response.Title);
+            }
+
+            [Fact]
+            public void Errors_InResponse()
+            {
+                /* Arrange */
+                var result = new ValidationResult("foo", new[] { "bar", "lorem" });
+                var ex = new ValidationException(result);
+                var expected = new Dictionary<string, IEnumerable<string>>
+                {
+                    { "bar", new[] { "foo" } },
+                    { "lorem", new[] { "foo" } },
+                };
+
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal(expected, response.Errors);
+            }
+        }
+
+        public class OnActivationException : ExceptionExtensionsTests
+        {
+            private readonly ActivationException ex;
+
+            public OnActivationException()
+            {
+                ex = new ActivationException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToNotFoundResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(404)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToNotFound()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/not-found", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_ExceptionMessageMappedInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("foo", response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("Resource not found", response.Title);
+            }
+
+            [Fact]
+            public void Errors_NotInResponse()
+            {
+                /* Arrange */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnResourceNotFoundException : ExceptionExtensionsTests
+        {
+            private readonly ResourceNotFoundException ex;
+
+            public OnResourceNotFoundException()
+            {
+                ex = new ResourceNotFoundException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToNotFoundResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(404)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToNotFound()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/not-found", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_ExceptionMessageMappedInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("foo", response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("Resource not found", response.Title);
+            }
+
+            [Fact]
+            public void Errors_NotInResponse()
+            {
+                /* Arrange */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnSecurityResourceException : ExceptionExtensionsTests
+        {
+            private readonly SecurityResourceException ex;
+
+            public OnSecurityResourceException()
+            {
+                ex = new SecurityResourceException("foo", "bar");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToForbiddenResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(403)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToInsufficientPrivileges()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/insufficient-privileges", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_OmittedBecauseInDetail()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("Insufficient privileges", response.Title);
+            }
+
+            [Fact]
+            public void Errors_ResourceAndMessageInResponse()
+            {
+                /*  */
+                var expected = new Dictionary<string, IEnumerable<string>>
+                {
+                    { "foo", new[] { "bar" } }
+                };
+
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal(expected, response.Errors);
+            }
+        }
+
+        public class OnSecurityException : ExceptionExtensionsTests
+        {
+            private readonly SecurityException ex;
+
+            public OnSecurityException()
+            {
+                ex = new SecurityException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToForbiddenResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(403)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToInsufficientPrivileges()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/insufficient-privileges", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_ExceptionMessageMapped()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("foo", response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("Insufficient privileges", response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnDBConcurrencyException : ExceptionExtensionsTests
+        {
+            private readonly DBConcurrencyException ex;
+
+            public OnDBConcurrencyException()
+            {
+                ex = new DBConcurrencyException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToConflictResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(409)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToConflict()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/conflict", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal(
+                    "There was a conflict while updating your data. Please try again. " +
+                    "If you continue to see this error please contact support.",
+                    response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("There was a conflict while updating your data.", response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnNotSupportedException : ExceptionExtensionsTests
+        {
+            private readonly NotSupportedException ex;
+
+            public OnNotSupportedException()
+            {
+                ex = new NotSupportedException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToNotImplementedResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(501)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToNotSupported()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/not-supported", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_Omitted()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("The operation is not supported.", response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnNotImplementedException : ExceptionExtensionsTests
+        {
+            private readonly NotImplementedException ex;
+
+            public OnNotImplementedException()
+            {
+                ex = new NotImplementedException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToNotImplementedResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(501)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToNotSupported()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/not-supported", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_Omitted()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("The operation is not supported.", response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnInvalidOperationException : ExceptionExtensionsTests
+        {
+            private readonly InvalidOperationException ex;
+
+            public OnInvalidOperationException()
+            {
+                ex = new InvalidOperationException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToBadRequestResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(400)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToNotSupported()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/not-supported", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_MappedFromExceptionMessage()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("foo", response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("The operation is not supported because of bad data.",
+                    response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnTaskCanceledException : ExceptionExtensionsTests
+        {
+            private readonly TaskCanceledException ex;
+
+            public OnTaskCanceledException()
+            {
+                ex = new TaskCanceledException("foo");
+            }
+
+            [Fact]
+            public void StatusCode_MappedToBadRequestResponse()
+            {
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(400)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToCanceled()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/canceled", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_Omitted()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("The request has been canceled.",
+                    response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+
+        public class OnAggregateException : ExceptionExtensionsTests
+        {
+            private AggregateException ex;
+
+            public OnAggregateException()
+            {
+                ex = new AggregateException(new Exception[]
+                {
+                    new ValidationException("foo", "bar"),
+                    new InvalidOperationException("lorem")
+                });
+            }
+
+            [Fact]
+            public void StatusCode_MappedFromLastException()
+            {
+                /* Act */
+                ex = new AggregateException(new Exception[]
+                {
+                    new ValidationException("foo", "bar"),
+                    new SecurityException("ipsum"),
+                });
+
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(403)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToNotSupported()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/multiple-errors", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_Omitted()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("Multiple Errors Occurred. Please see the errros.",
+                    response.Title);
+            }
+
+            [Fact]
+            public void Errors_MappedFromInnerExceptions()
+            {
+                /* Arrange */
+                ex = new AggregateException(new Exception[]
+                {
+                    new ValidationException("foo", "bar"),
+                    new InvalidOperationException("lorem"),
+                    new TaskCanceledException("lorem")
+                });
+
+                var expected = new Dictionary<string, IEnumerable<string>>
+                {
+                    { "foo", new[] { "bar" } },
+                    { "", new[] { "lorem", "The request has been canceled." } }
+                };
+
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal(expected, response.Errors);
+            }
+        }
+
+        public class OnException : ExceptionExtensionsTests
+        {
+            private Exception ex;
+
+            public OnException()
+            {
+                ex = new Exception();
+            }
+
+            [Fact]
+            public void StatusCode_MappedToInternalServerError()
+            {
+                /* Arrange */
+                A.CallTo(() => http.Response.StatusCode).Returns(200);
+
+                /* Act */
+                ex.MapToWebResponse(http);
+
+                /* Assert */
+                A.CallToSet(() => http.Response.StatusCode).To(500)
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public void Url_MappedToUnknown()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("/docs/errors/unexpected", response.Type.AbsolutePath);
+            }
+
+            [Fact]
+            public void DetailMessage_MappedFromStrig()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("An unexpected error has occurred in the system. " +
+                    "The problem has been logged. Please contact support if this " +
+                    "issue persists without our acknowledgment.",
+                    response.Detail);
+            }
+
+            [Fact]
+            public void Title_InResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Equal("An unexpected error has occurred in the system.",
+                    response.Title);
+            }
+
+            [Fact]
+            public void Errors_EmptyInResponse()
+            {
+                /* Act */
+                var response = ex.MapToWebResponse(http);
+
+                /* Assert */
+                Assert.Empty(response.Errors);
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/HttpContextFakeFactory.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/HttpContextFakeFactory.cs
@@ -1,0 +1,32 @@
+namespace BusinessApp.WebApi.UnitTest
+{
+    using Microsoft.AspNetCore.Http;
+    using System.Security.Claims;
+    using FakeItEasy;
+
+    public static class HttpContextFakeFactory
+    {
+        public static HttpContext New(ClaimsPrincipal principal = null,
+          HttpRequest request = null, HttpResponse response = null)
+        {
+            var fakeCtx = A.Fake<HttpContext>();
+            var fakeReq = A.Fake<HttpRequest>();
+            var fakeRes = A.Fake<HttpResponse>();
+
+            A.CallTo(() => fakeCtx.Request).Returns(request ?? fakeReq);
+            A.CallTo(() => fakeCtx.Response).Returns(response ?? fakeRes);
+
+            A.CallTo(() => fakeReq.Scheme).Returns("https");
+            A.CallTo(() => fakeReq.Host).Returns(new HostString("foobar"));
+
+            if (principal == null)
+            {
+                principal = ClaimsPrincipalFakeFactory.New();
+            }
+
+            A.CallTo(() => fakeCtx.User).Returns(principal);
+
+            return fakeCtx;
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/ExceptionExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/ExceptionExtensions.cs
@@ -52,7 +52,7 @@
                     context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
                     errorType = "insufficient-privileges";
                     title = "Insufficient privileges";
-                    detail = sre.Message;
+                    detail = "";
                     errors = new Dictionary<string, IEnumerable<string>>
                     {
                         { sre.ResourceName, new[] { sre.Message } }

--- a/CSharp/src/BusinessApp.WebApi/ExceptionExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/ExceptionExtensions.cs
@@ -1,94 +1,143 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace BusinessApp.WebApi
+﻿namespace BusinessApp.WebApi
 {
     using System;
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
     using System.Net;
-    using System.Net.Http;
     using System.Security;
     using System.Threading.Tasks;
     using BusinessApp.App;
     using BusinessApp.Domain;
     using Microsoft.AspNetCore.Http;
+    using SimpleInjector;
 
     public static class ExceptionExtensions
     {
         /// <summary>
-        /// Allows translating exceptions to <see cref="ResponseProblemBody />
+        /// Allows translating exceptions to <see cref="ResponseProblemBody" />
         /// </summary>
         public static ResponseProblemBody MapToWebResponse(this Exception exception, HttpContext context)
         {
             string errorType = "server-error";
             string title = "Server Error";
-            IDictionary<string, IEnumerable<string>> errors =
-                new Dictionary<string, IEnumerable<string>>();
+            string detail = null;
+            var errors = new Dictionary<string, IEnumerable<string>>();
 
             switch (exception)
             {
                 // The supplied model isn't valid.
-                case NotImplementedException _:
-                    context.Response.StatusCode = 501;
-                    errorType = "not-supported";
-                    title = "Function not supported";
-                    break;
                 case BadStateException _:
-                case ValidationException _:
                     context.Response.StatusCode = 400;
                     errorType = "invalid-model";
                     title = "Invalid Model";
-                    errors = exception.Data.Keys.Cast<string>()
-                        .ToDictionary(key => key, key => (IEnumerable<string>)exception.Data[key]);
                     break;
-                case EntityNotFoundException _:
+                case ValidationException ve:
+                    context.Response.StatusCode = 400;
+                    errorType = "invalid-data";
+                    title = "Invalid Data";
+                    detail = "Your data was not accepted because it is not valid. Please fix the errors";
+                    errors = ve.Result.MemberNames
+                        .ToDictionary(
+                        member => member,
+                        member => (IEnumerable<string>)new[] { ve.Result.ErrorMessage });
+                    break;
+                case ActivationException _:
                 case ResourceNotFoundException _:
                     context.Response.StatusCode = (int)HttpStatusCode.NotFound;
                     errorType = "not-found";
                     title = "Resource not found";
                     break;
-                // The current user doesn't have the proper rights to execute the requested
-                case SecurityException _:
-                    context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                case SecurityResourceException sre:
+                    context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
                     errorType = "insufficient-privileges";
                     title = "Insufficient privileges";
+                    detail = sre.Message;
+                    errors = new Dictionary<string, IEnumerable<string>>
+                    {
+                        { sre.ResourceName, new[] { sre.Message } }
+                    };
                     break;
-                case FormatException _:
-                    context.Response.StatusCode = (int)HttpStatusCode.UnprocessableEntity;
-                    errorType = "malformed-data";
-                    title = "Bad Data";
+                case SecurityException se:
+                    context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                    errorType = "insufficient-privileges";
+                    title = "Insufficient privileges";
+                    detail = se.Message;
                     break;
                 case DBConcurrencyException ex:
                     context.Response.StatusCode = (int)HttpStatusCode.Conflict;
                     errorType = "conflict";
-                    title = ex.Message;
+                    title = "There was a conflict while updating your data.";
+                    detail = $"{title} Please try again. " +
+                        "If you continue to see this error please contact support.";
                     break;
-                case NotSupportedException ex:
+                case NotImplementedException _:
+                case NotSupportedException _:
+                    context.Response.StatusCode = (int)HttpStatusCode.NotImplemented;
                     errorType = "not-supported";
-                    title = "The operation is not supported";
+                    title = "The operation is not supported.";
+                    detail = "";
                     break;
                 case TaskCanceledException ex:
                     context.Response.StatusCode = 400;
-                    errorType = "cancelled";
-                    title = ex.Message;
+                    errorType = "canceled";
+                    title = "The request has been canceled.";
+                    detail = "";
+                    break;
+                case InvalidOperationException ex:
+                    context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                    errorType = "not-supported";
+                    title = "The operation is not supported because of bad data.";
+                    detail = ex.Message;
                     break;
                 case AggregateException manyExceptions:
-                    foreach(var ex in manyExceptions.Flatten().InnerExceptions)
-                    {
-                        var response = ex.MapToWebResponse(context);
+                    var responses = new List<ResponseProblemBody>();
 
-                        if (response.Status != (int)HttpStatusCode.InternalServerError)
-                        {
-                            return response;
-                        }
+                    foreach (var ex in manyExceptions.Flatten().InnerExceptions)
+                    {
+                        responses.Add(ex.MapToWebResponse(context));
                     }
-                    break;
+
+                    return new ResponseProblemBody(context.Response.StatusCode,
+                        "Multiple Errors Occurred. Please see the errros.",
+                        context.CreateProblemUri("multiple-errors"))
+                    {
+                        Detail = "",
+                        Errors = responses.Aggregate(
+                            new Dictionary<string, IEnumerable<string>>(),
+                            (accu, problem) =>
+                            {
+                                if (!problem.Errors.Any())
+                                {
+                                    AddProblemErrors(accu,
+                                        "",
+                                        new[]
+                                        {
+                                            string.IsNullOrWhiteSpace(problem.Detail) ?
+                                            problem.Title :
+                                            problem.Detail
+                                        });
+                                }
+                                else
+                                {
+                                    foreach (var error in problem.Errors)
+                                    {
+                                        AddProblemErrors(accu, error.Key, error.Value);
+                                    }
+                                }
+
+                                return accu;
+                            })
+                    };
                 default:
-                    if (new HttpResponseMessage((HttpStatusCode)context.Response.StatusCode).IsSuccessStatusCode)
+                    if (context.Response.IsSuccess())
                     {
                         context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
                     }
+                    errorType = "unexpected";
+                    title = "An unexpected error has occurred in the system.";
+                    detail = $"{title} The problem has been logged. Please contact support " +
+                        "if this issue persists without our acknowledgment.";
                     break;
             }
 
@@ -97,16 +146,21 @@ namespace BusinessApp.WebApi
                 context.CreateProblemUri(errorType)
             )
             {
-                Detail = exception.Message,
+                Detail = detail ?? exception.Message,
                 Errors = errors
             };
         }
 
-        public static ValidationException ToException(this ResponseProblemBody problem)
+        private static void AddProblemErrors(IDictionary<string, IEnumerable<string>> accu, string key, IEnumerable<string> value)
         {
-            return new ValidationException(
-                new CompositeValidationResult(problem.Detail,
-                problem.Errors.SelectMany(e => e.Value.Select(v => new ValidationResult(v, new[] { e.Key })))));
+            if (!accu.TryGetValue(key, out IEnumerable<string> messages))
+            {
+                accu.Add(key, value);
+            }
+            else
+            {
+                accu[key] = messages.Concat(value).ToArray();
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/HttpResponseExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpResponseExtensions.cs
@@ -1,0 +1,12 @@
+namespace BusinessApp.WebApi
+{
+    using Microsoft.AspNetCore.Http;
+
+    public static class HttpResponseExtensions
+    {
+        public static bool IsSuccess(this HttpResponse response)
+        {
+            return response.StatusCode >= 200 && response.StatusCode <= 299;
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/ResourceNotFoundException.cs
+++ b/CSharp/src/BusinessApp.WebApi/ResourceNotFoundException.cs
@@ -5,9 +5,10 @@
     /// <summary>
     /// Exception when a resource was expected, but not found
     /// </summary>
+    [Serializable]
     public class ResourceNotFoundException : Exception
     {
-        public ResourceNotFoundException(string message = null)
+        public ResourceNotFoundException(string message = null, Exception inner = null)
             : base(message ?? "The resource you are looking for does not exist")
         { }
     }

--- a/CSharp/src/BusinessApp.WebApi/ResourceNotFoundRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/ResourceNotFoundRequestDecorator.cs
@@ -20,14 +20,21 @@
 
         public async Task<TResponse> HandleAsync(HttpContext context, CancellationToken cancellationToken)
         {
-            var resource = await decorated.HandleAsync(context, cancellationToken);
-
-            if (resource == null)
+            try
             {
-                throw new ResourceNotFoundException();
-            }
+                var resource = await decorated.HandleAsync(context, cancellationToken);
 
-            return resource;
+                if (resource == null)
+                {
+                    throw new ResourceNotFoundException();
+                }
+
+                return resource;
+            }
+            catch (EntityNotFoundException e)
+            {
+                throw new ResourceNotFoundException(e.Message, e);
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.sln
+++ b/CSharp/src/BusinessApp.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApp.Domain.UnitTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApp.Test.Common", "BusinessApp.Test.Common\BusinessApp.Test.Common.csproj", "{DCBD287A-9BC4-4EE5-BB10-1D766E11D38F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApp.WebApi.UnitTest", "BusinessApp.WebApi.UnitTest\BusinessApp.WebApi.UnitTest.csproj", "{CF076CD2-214C-4FB7-ACEA-940A93002D43}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -140,6 +142,18 @@ Global
 		{DCBD287A-9BC4-4EE5-BB10-1D766E11D38F}.Release|x64.Build.0 = Release|Any CPU
 		{DCBD287A-9BC4-4EE5-BB10-1D766E11D38F}.Release|x86.ActiveCfg = Release|Any CPU
 		{DCBD287A-9BC4-4EE5-BB10-1D766E11D38F}.Release|x86.Build.0 = Release|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x64.Build.0 = Release|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Batch commands need to be index to match errors messages up for clients.
Cleanup error messages to make them clearer

closes #13, #10