### PR TITLE
fix(Validator): Do not collect and throw all errors

### DIFF
--- a/CSharp/src/BusinessApp.App/CompositeValidator.cs
+++ b/CSharp/src/BusinessApp.App/CompositeValidator.cs
@@ -1,8 +1,6 @@
 namespace BusinessApp.App
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using BusinessApp.Domain;
 
@@ -20,30 +18,9 @@ namespace BusinessApp.App
 
         public async Task ValidateAsync(T instance)
         {
-            var errors = new List<ValidationException>();
-
             foreach (var validator in validators)
             {
-                try
-                {
-                    await validator.ValidateAsync(instance);
-                }
-                catch (ValidationException ex)
-                {
-                    errors.Add(ex);
-                }
-            }
-
-            if (errors.Any())
-            {
-                if (errors.Count == 1)
-                {
-                    throw errors.First();
-                }
-                else
-                {
-                    throw new AggregateException(errors);
-                }
+                await validator.ValidateAsync(instance);
             }
         }
     }


### PR DESCRIPTION
* Old logic assumed that all validators could be run even if priors
  failed. However, for example, if a data annotation fails, then I would
  assumed that any future validator would not run because they could
  assume to have particular properties the data annotations validates.
  This allows for a logical order of validation to occur, so if one fails,
  the rest will not be run, and future validators do not have to recheck
  properties.