### PR TITLE
feat(Contract): Add Envelope contract for pagination

### DIFF
--- a/CSharp/src/BusinessApp.App/EnvelopeContract.cs
+++ b/CSharp/src/BusinessApp.App/EnvelopeContract.cs
@@ -1,0 +1,11 @@
+namespace BusinessApp.App
+{
+    using System.Collections.Generic;
+
+    public class EnvelopeContract<TContract>
+    {
+        public IEnumerable<TContract> Data { get; set; }
+
+        public Pagination Pagination { get; set; }
+    }
+}

--- a/CSharp/src/BusinessApp.App/Pagination.cs
+++ b/CSharp/src/BusinessApp.App/Pagination.cs
@@ -1,0 +1,7 @@
+namespace BusinessApp.App
+{
+    public class Pagination
+    {
+        public int ItemCount { get; set; }
+    }
+}

--- a/CSharp/src/BusinessApp.Data.UnitTest/BusinessApp.Data.UnitTest.csproj
+++ b/CSharp/src/BusinessApp.Data.UnitTest/BusinessApp.Data.UnitTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BusinessApp.Data\BusinessApp.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CSharp/src/BusinessApp.Data.UnitTest/BusinessAppDbContextDummyFactory.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/BusinessAppDbContextDummyFactory.cs
@@ -1,0 +1,15 @@
+namespace BusinessApp.Data.UnitTest
+{
+    using FakeItEasy;
+    using Microsoft.EntityFrameworkCore;
+
+    public class BusinessAppReadOnlyDbContextDummyFactory : DummyFactory<BusinessAppReadOnlyDbContext>
+    {
+        protected override BusinessAppReadOnlyDbContext Create()
+        {
+            return new BusinessAppReadOnlyDbContext(new DbContextOptionsBuilder<BusinessAppReadOnlyDbContext>()
+                .UseSqlServer("Server=(localdb)\\MSSQLLocalDb;Initial Catalog=foobar")
+                .Options);
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Data.UnitTest/Dummies.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/Dummies.cs
@@ -1,0 +1,9 @@
+namespace BusinessApp.Data.UnitTest
+{
+    using BusinessApp.App;
+
+    public class DummyResponse {}
+
+    public class DummyRequest : Query, IQuery<EnvelopeContract<DummyResponse>> { }
+}
+

--- a/CSharp/src/BusinessApp.Data.UnitTest/EFEnvelopedQueryHandlerTests.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/EFEnvelopedQueryHandlerTests.cs
@@ -1,0 +1,167 @@
+namespace BusinessApp.Data.UnitTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FakeItEasy;
+    using Microsoft.EntityFrameworkCore;
+    using Xunit;
+
+    public class EFEnvelopedQueryHandlerTests
+    {
+        private readonly BusinessAppReadOnlyDbContext db;
+        private readonly IDbSetVisitorFactory<DummyRequest, DummyResponse> dbSetFactory;
+        private readonly IQueryVisitorFactory<DummyRequest, DummyResponse> queryVisitorFactory;
+        private EFEnvelopedQueryHandler<DummyRequest, DummyResponse> sut;
+
+        public EFEnvelopedQueryHandlerTests()
+        {
+            db = A.Dummy<BusinessAppReadOnlyDbContext>();
+            dbSetFactory = A.Fake<IDbSetVisitorFactory<DummyRequest, DummyResponse>>();
+            queryVisitorFactory = A.Fake<IQueryVisitorFactory<DummyRequest, DummyResponse>>();
+
+            sut = new EFEnvelopedQueryHandler<DummyRequest, DummyResponse>(db, queryVisitorFactory, dbSetFactory);
+        }
+
+        public class Constructor : EFEnvelopedQueryHandlerTests
+        {
+            public static IEnumerable<object[]> InvalidCtorArgs => new[]
+            {
+                new object[]
+                {
+                    null,
+                    A.Dummy<IQueryVisitorFactory<DummyRequest, DummyResponse>>(),
+                    A.Dummy<IDbSetVisitorFactory<DummyRequest, DummyResponse>>()
+                },
+                new object[]
+                {
+                    A.Dummy<BusinessAppReadOnlyDbContext>(),
+                    null,
+                    A.Dummy<IDbSetVisitorFactory<DummyRequest, DummyResponse>>()
+                },
+                new object[]
+                {
+                    A.Dummy<BusinessAppReadOnlyDbContext>(),
+                    A.Dummy<IQueryVisitorFactory<DummyRequest, DummyResponse>>(),
+                    null
+                }
+            };
+
+            [Theory, MemberData(nameof(InvalidCtorArgs))]
+            public void InvalidCtorArgs_ExceptionThrown(BusinessAppReadOnlyDbContext r,
+                IQueryVisitorFactory<DummyRequest, DummyResponse> q,
+                IDbSetVisitorFactory<DummyRequest, DummyResponse> d)
+            {
+                /* Arrange */
+                void shouldThrow() => new EFEnvelopedQueryHandler<DummyRequest, DummyResponse>(r, q, d);
+
+                /* Act */
+                var ex = Record.Exception(shouldThrow);
+
+                /* Assert */
+                Assert.IsType<ArgumentNullException>(ex);
+            }
+        }
+
+        public class HandleAsync : EFEnvelopedQueryHandlerTests
+        {
+            private readonly IQueryable<DummyResponse> results;
+            private readonly DummyRequest query;
+            private readonly IDbSetVisitor<DummyResponse> dbSetVisitor;
+            private readonly IQueryVisitor<DummyResponse> queryVisitor;
+
+            public HandleAsync()
+            {
+                query = new DummyRequest();
+
+                dbSetVisitor = A.Fake<IDbSetVisitor<DummyResponse>>();
+                queryVisitor = A.Fake<IQueryVisitor<DummyResponse>>();
+                A.CallTo(() => dbSetFactory.Create(query)).Returns(dbSetVisitor);
+                A.CallTo(() => queryVisitorFactory.Create(query)).Returns(queryVisitor);
+
+                results = new[]
+                {
+                    new DummyResponse(),
+                    new DummyResponse(),
+                    new DummyResponse()
+                }.AsQueryable();
+
+                A.CallTo(() => dbSetVisitor.Visit(A<DbSet<DummyResponse>>._))
+                    .Returns(results);
+                A.CallTo(() => queryVisitor.Visit(A<IQueryable<DummyResponse>>._))
+                    .Returns(new FakeQueryable<DummyResponse>(results));
+            }
+
+            [Theory]
+            [InlineData(0)]
+            [InlineData(null)]
+            public async Task WithNoQueryParams_ReturnsAll(int? offset)
+            {
+                /* Arrange */
+                query.Offset = offset;
+
+                /* Act */
+                var returnedData = await sut.HandleAsync(query, A.Dummy<CancellationToken>());
+
+                /* Assert */
+                Assert.Equal(3, returnedData.Data.Count());
+            }
+
+            [Fact]
+            public async Task WithOffset_LimitsData()
+            {
+                /* Arrange */
+                query.Offset = 1;
+
+                /* Act */
+                var returnedData = await sut.HandleAsync(query, A.Dummy<CancellationToken>());
+
+                /* Assert */
+                Assert.Equal(2, returnedData.Data.Count());
+            }
+
+            [Fact]
+            public async Task WithLimit_FirstTaken()
+            {
+                /* Arrange */
+                query.Limit = 1;
+
+                /* Act */
+                var returnedData = await sut.HandleAsync(query, A.Dummy<CancellationToken>());
+
+                /* Assert */
+                Assert.Same(results.First(), Assert.Single(returnedData.Data));
+            }
+
+            [Fact]
+            public async Task WithLimitAndOffset_DatasetFiltered()
+            {
+                /* Arrange */
+                query.Limit = 1;
+                query.Offset = 2;
+
+                /* Act */
+                var returnedData = await sut.HandleAsync(query, A.Dummy<CancellationToken>());
+
+                /* Assert */
+                Assert.Same(results.Last(), Assert.Single(returnedData.Data));
+            }
+
+            [Fact]
+            public async Task WithLimitAndOffset_TotalCountNotAffected()
+            {
+                /* Arrange */
+                query.Limit = 1;
+                query.Offset = 2;
+
+                /* Act */
+                var returnedData = await sut.HandleAsync(query, A.Dummy<CancellationToken>());
+
+                /* Assert */
+                Assert.Equal(3, returnedData.Pagination.ItemCount);
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Data.UnitTest/FakeQueryable.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/FakeQueryable.cs
@@ -1,0 +1,72 @@
+namespace BusinessApp.Data.UnitTest
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class FakeQueryable<T> : IAsyncEnumerable<T>, IQueryable<T>
+    {
+        private readonly IEnumerable<T> resultSet;
+
+        public FakeQueryable(IEnumerable<T> resultSet)
+        {
+            this.resultSet = resultSet;
+        }
+
+        public Type ElementType => throw new NotImplementedException();
+
+        public Expression Expression => throw new NotImplementedException();
+
+        public IQueryProvider Provider => throw new NotImplementedException();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new FakeEnumerator(resultSet);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new FakeEnumerator(resultSet);
+        }
+
+        IAsyncEnumerator<T> IAsyncEnumerable<T>.GetEnumerator()
+        {
+            return new FakeEnumerator(resultSet);
+        }
+
+        private class FakeEnumerator : IAsyncEnumerator<T>, IEnumerator<T>
+        {
+            readonly IEnumerator<T> inner;
+
+            public FakeEnumerator(IEnumerable<T> resultSet)
+            {
+                inner = resultSet.GetEnumerator();
+            }
+
+            public T Current => inner.Current;
+
+            object IEnumerator.Current => inner.Current;
+
+            public void Dispose()
+            {
+                inner.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                return inner.MoveNext();
+            }
+
+            public Task<bool> MoveNext(CancellationToken cancellationToken)
+            {
+                return Task.FromResult(MoveNext());
+            }
+
+            public void Reset() => inner.Reset();
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Data/EFEnvelopedQueryHandler.cs
+++ b/CSharp/src/BusinessApp.Data/EFEnvelopedQueryHandler.cs
@@ -1,0 +1,52 @@
+namespace BusinessApp.Data
+{
+    using Microsoft.EntityFrameworkCore;
+    using System.Threading.Tasks;
+    using BusinessApp.App;
+    using BusinessApp.Domain;
+    using System.Linq;
+    using System.Threading;
+
+    public class EFEnvelopedQueryHandler<TQuery, TResult> : IQueryHandler<TQuery, EnvelopeContract<TResult>>
+        where TQuery : Query, IQuery<EnvelopeContract<TResult>>
+        where TResult : class
+    {
+        private readonly BusinessAppReadOnlyDbContext db;
+        private readonly IDbSetVisitorFactory<TQuery, TResult> dbSetFactory;
+        private readonly IQueryVisitorFactory<TQuery, TResult> queryVisitorFactory;
+
+        public EFEnvelopedQueryHandler(BusinessAppReadOnlyDbContext db,
+            IQueryVisitorFactory<TQuery, TResult> queryVisitorFactory,
+            IDbSetVisitorFactory<TQuery, TResult> dbSetFactory)
+        {
+            this.db = GuardAgainst.Null(db, nameof(db));
+            this.queryVisitorFactory = GuardAgainst.Null(queryVisitorFactory, nameof(queryVisitorFactory));
+            this.dbSetFactory = GuardAgainst.Null(dbSetFactory, nameof(dbSetFactory));
+        }
+
+        public async Task<EnvelopeContract<TResult>> HandleAsync(TQuery query,
+            CancellationToken cancellationToken)
+        {
+            var dbSetVisitor = dbSetFactory.Create(query);
+            var queryVisitor = queryVisitorFactory.Create(query);
+            var queryable = dbSetVisitor.Visit(db.Set<TResult>());
+
+            // handle these values here
+            var take = query.Limit;
+            var skip = query.Offset ?? 0;
+            query.Limit = null;
+            query.Offset = null;
+
+            var data = await queryVisitor.Visit(queryable).ToListAsync();
+
+            return new EnvelopeContract<TResult>
+            {
+                Data = data.Skip(skip).Take(take ?? data.Count),
+                Pagination = new Pagination
+                {
+                    ItemCount = data.Count
+                }
+            };
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/CommandResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/CommandResourceHandler.cs
@@ -27,6 +27,12 @@
         public async Task<TRequest> HandleAsync(HttpContext context, CancellationToken cancellationToken)
         {
             var command = context.DeserializeInto<TRequest>(serializer);
+
+            if (command == null)
+            {
+                throw new ValidationException("No Data found");
+            }
+
             await handler.HandleAsync(command, cancellationToken);
 
             return command;

--- a/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
@@ -1,0 +1,44 @@
+namespace BusinessApp.WebApi
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Primitives;
+    using BusinessApp.App;
+    using BusinessApp.Domain;
+
+    public class EnvelopeQueryResourceHandler<TRequest, TResponse> :
+        IResourceHandler<TRequest, IEnumerable<TResponse>>
+        where TRequest : IQuery<EnvelopeContract<TResponse>>, new()
+    {
+        private readonly IQueryHandler<TRequest, EnvelopeContract<TResponse>> handler;
+        private readonly ISerializer serializer;
+
+        public EnvelopeQueryResourceHandler(
+            IQueryHandler<TRequest, EnvelopeContract<TResponse>> handler,
+            ISerializer serializer)
+        {
+            this.handler = GuardAgainst.Null(handler, nameof(handler));
+            this.serializer = GuardAgainst.Null(serializer, nameof(serializer));
+        }
+
+        public async Task<IEnumerable<TResponse>> HandleAsync(HttpContext context, CancellationToken cancellationToken)
+        {
+            var query = context.DeserializeInto<TRequest>(serializer);
+
+            if (query == null)
+            {
+                query = new TRequest();
+            }
+
+            var resource = await handler.HandleAsync(query, cancellationToken);
+
+            context.Response.Headers.Add("Access-Control-Expose-Headers", new[] { "VND.parkeremg.pagination" });
+            context.Response.Headers.Add("VND.parkeremg.pagination",
+                new StringValues(resource.Pagination.ToHeaderValue()));
+
+            return resource.Data;
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/HttpContextExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpContextExtensions.cs
@@ -14,9 +14,7 @@
         /// Deserializes the uri or body depending on the request method
         /// </summary>
         public static T DeserializeInto<T>(this HttpContext context,
-            ISerializer serializer
-        )
-            where T : class, new()
+            ISerializer serializer)
         {
             if (context.Request.Method.Equals("get", StringComparison.OrdinalIgnoreCase) ||
                 context.Request.Method.Equals("delete", StringComparison.OrdinalIgnoreCase)
@@ -25,19 +23,19 @@
                 // TODO might not be able to do Sync. Deserialization see ShelfLife 3.1 commit
                 using (var stream = DeserializeUri(context, serializer))
                 {
-                    return serializer.Deserialize<T>(stream) ?? new T();
+                    return serializer.Deserialize<T>(stream);
                 }
             }
             else if (context.Request.ContentLength == null || context.Request.ContentLength > 0)
             {
-                return serializer.Deserialize<T>(context.Request.Body) ?? new T();
+                return serializer.Deserialize<T>(context.Request.Body);
             }
 
-            return new T();
+            return default(T);
         }
 
         /// <summary>
-        /// Helper class to create the <see cref="ResponseProblemBody.Type />
+        /// Helper class to create the <see cref="ResponseProblemBody.Type"/>
         /// </summary>
         /// <param name="context"></param>
         /// <param name="errorType"></param>

--- a/CSharp/src/BusinessApp.WebApi/HttpPaginationExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpPaginationExtensions.cs
@@ -1,0 +1,16 @@
+namespace BusinessApp.WebApi
+{
+    using BusinessApp.App;
+
+    public  static class HttpPaginationExtensions
+    {
+        public static string[] ToHeaderValue(this Pagination page)
+        {
+            return new[]
+            {
+                $"count={page.ItemCount}"
+            };
+        }
+    }
+
+}

--- a/CSharp/src/BusinessApp.WebApi/QueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/QueryResourceHandler.cs
@@ -17,8 +17,7 @@
 
         public QueryResourceHandler(
             IQueryHandler<TRequest, TResponse> handler,
-            ISerializer serializer
-        )
+            ISerializer serializer)
         {
             this.handler = GuardAgainst.Null(handler, nameof(handler));
             this.serializer = GuardAgainst.Null(serializer, nameof(serializer));
@@ -28,6 +27,11 @@
             CancellationToken cancellationToken)
         {
             var query = context.DeserializeInto<TRequest>(serializer);
+
+            if (query == null)
+            {
+                query = new TRequest();
+            }
 
             return await handler.HandleAsync(query, cancellationToken);
         }

--- a/CSharp/src/BusinessApp.sln
+++ b/CSharp/src/BusinessApp.sln
@@ -36,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApp.Test.Common", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApp.WebApi.UnitTest", "BusinessApp.WebApi.UnitTest\BusinessApp.WebApi.UnitTest.csproj", "{CF076CD2-214C-4FB7-ACEA-940A93002D43}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApp.Data.UnitTest", "BusinessApp.Data.UnitTest\BusinessApp.Data.UnitTest.csproj", "{7091D95E-9C3B-45E4-9FE7-131413D69F06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -154,6 +156,18 @@ Global
 		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x64.Build.0 = Release|Any CPU
 		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x86.ActiveCfg = Release|Any CPU
 		{CF076CD2-214C-4FB7-ACEA-940A93002D43}.Release|x86.Build.0 = Release|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Debug|x64.Build.0 = Debug|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Debug|x86.Build.0 = Debug|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Release|x64.ActiveCfg = Release|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Release|x64.Build.0 = Release|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Release|x86.ActiveCfg = Release|Any CPU
+		{7091D95E-9C3B-45E4-9FE7-131413D69F06}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Envelope contract should hold metadata for query, for example pagination.
That way the entire result set does not need to be fetch and the client
can get other details about the query for a better experience. Use HTTP
headers to hold this data.

closes #27