### PR TITLE
fix(uow): Continually emit events if they exist

### DIFF
--- a/CSharp/src/BusinessApp.Domain.UnitTest/AggregateRootFake.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/AggregateRootFake.cs
@@ -1,0 +1,24 @@
+namespace BusinessApp.Domain.UnitTest
+{
+    using FakeItEasy;
+
+    public class AggregateRootFake : AggregateRoot
+    {
+        public void AddEvent(IDomainEvent @event = null)
+        {
+            Events.Add(@event ?? A.Dummy<IDomainEvent>());
+        }
+
+        public void ClearEvents(IDomainEvent @event = null)
+        {
+            if (@event != null)
+            {
+                Events.Remove(@event);
+            }
+            else
+            {
+                Events.Clear();
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Domain.UnitTest/EventUnitOfWorkTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EventUnitOfWorkTests.cs
@@ -1,0 +1,177 @@
+namespace BusinessApp.Domain.UnitTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using FakeItEasy;
+    using BusinessApp.Domain;
+    using Xunit;
+    using System.Threading;
+
+    public class EventUnitOfWorkTests
+    {
+        private readonly EventUnitOfWork sut;
+        private readonly IEventPublisher publisher;
+        private readonly CancellationToken token;
+
+        public EventUnitOfWorkTests()
+        {
+            token = A.Dummy<CancellationToken>();
+            publisher = A.Fake<IEventPublisher>();
+            sut = new EventUnitOfWork(publisher);
+        }
+
+        public class Constructor : EventUnitOfWorkTests
+        {
+            public static IEnumerable<object[]> InvalidCtorArgs
+            {
+                get
+                {
+                    return new[]
+                    {
+                        new object[] { null },
+                    };
+                }
+            }
+
+            [Theory, MemberData(nameof(InvalidCtorArgs))]
+            public void InvalidArgs_ExceptionThrown(IEventPublisher p)
+            {
+                /* Arrange */
+                void shouldThrow() => new EventUnitOfWork(p);
+
+                /* Act */
+                var ex = Record.Exception((Action)shouldThrow);
+
+                /* Assert */
+                Assert.IsType<ArgumentNullException>(ex);
+            }
+        }
+
+        public class CommitAsync : EventUnitOfWorkTests
+        {
+            [Fact]
+            public async Task WithNewAggregateRoot_EventsPublishBeforeOnCommit()
+            {
+                /* Arrange */
+                var aggregate = new AggregateRootFake();
+                aggregate.AddEvent();
+                sut.Add(aggregate);
+                A.CallTo(() => publisher.PublishAsync(aggregate, token))
+                    .Invokes(ctx =>
+                    {
+                        aggregate.ClearEvents();
+                    });
+
+                /* Act */
+                await sut.CommitAsync(token);
+
+                /* Assert */
+                A.CallTo(() => publisher.PublishAsync(aggregate, token))
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public async Task WithNewEventEmitter_EventsPublishBeforeOnCommit()
+            {
+                /* Arrange */
+                var emitter = A.Fake<IEventEmitter>();
+                A.CallTo(() => emitter.HasEvents()).Returns(true).Once();
+                sut.Add(emitter);
+
+                /* Act */
+                await sut.CommitAsync(token);
+
+                /* Assert */
+                A.CallTo(() => publisher.PublishAsync(emitter, token))
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
+            public async Task WithAggregate_EventsPublishWhileExists()
+            {
+                /* Arrange */
+                var aggregate = new AggregateRootFake();
+                int calls = 0;
+                aggregate.AddEvent();
+                sut.Add(aggregate);
+                A.CallTo(() => publisher.PublishAsync(aggregate, token))
+                    .Invokes(ctx =>
+                    {
+                        if (calls != 0)
+                        {
+                            aggregate.ClearEvents();
+                        }
+
+                        calls++;
+                    });
+
+                /* Act */
+                await sut.CommitAsync(token);
+
+                /* Assert */
+                A.CallTo(() => publisher.PublishAsync(aggregate, token))
+                    .MustHaveHappenedTwiceExactly();
+            }
+
+            [Fact]
+            public async Task WithEventEmitter_EventsPublishWhileExists()
+            {
+                /* Arrange */
+                var emitter = A.Fake<IEventEmitter>();
+                A.CallTo(() => emitter.HasEvents()).Returns(true).Twice();
+                sut.Add(emitter);
+
+                /* Act */
+                await sut.CommitAsync(token);
+
+                /* Assert */
+                A.CallTo(() => publisher.PublishAsync(emitter, token))
+                    .MustHaveHappenedOnceExactly();
+            }
+        }
+
+        public class Remove : EventUnitOfWorkTests
+        {
+            [Fact]
+            public async Task WithExistingEmitter_RemovesIt()
+            {
+                /* Arrange */
+                var aggregate = new AggregateRootFake();
+                aggregate.AddEvent();
+                sut.Add(aggregate);
+
+                /* Act */
+                sut.Remove(aggregate);
+
+                /* Assert */
+                await sut.CommitAsync(token);
+                A.CallTo(() => publisher.PublishAsync(A<AggregateRoot>._, A<CancellationToken>._))
+                    .MustNotHaveHappened();
+            }
+        }
+
+        public class RevertAsync : EventUnitOfWorkTests
+        {
+            [Fact]
+            public async Task WithPendingEmitters_RemovesAll()
+            {
+                /* Arrange */
+                var first = new AggregateRootFake();
+                var second = new AggregateRootFake();
+                first.AddEvent();
+                second.AddEvent();
+                sut.Add(first);
+                sut.Add(second);
+
+                /* Act */
+                await sut.RevertAsync(token);
+
+                /* Assert */
+                await sut.CommitAsync(token);
+                A.CallTo(() => publisher.PublishAsync(A<AggregateRoot>._, A<CancellationToken>._))
+                    .MustNotHaveHappened();
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Domain/AggregateRoot.cs
+++ b/CSharp/src/BusinessApp.Domain/AggregateRoot.cs
@@ -11,6 +11,8 @@
         protected ICollection<IDomainEvent> Events { get; }
             = new List<IDomainEvent>();
 
+        public bool HasEvents() => Events.Count > 0;
+
         public IEnumerable<IDomainEvent> PublishEvents()
         {
             var events = Events.ToArray();

--- a/CSharp/src/BusinessApp.Domain/IEventEmitter.cs
+++ b/CSharp/src/BusinessApp.Domain/IEventEmitter.cs
@@ -7,6 +7,7 @@
     /// </summary>
     public interface IEventEmitter
     {
+        bool HasEvents();
         IEnumerable<IDomainEvent> PublishEvents();
     }
 }


### PR DESCRIPTION
Always check for events after events are emitted to support event
chaining. A future aggregate can emit an event that a past aggregate
needs to emit.