### PR TITLE
chore(build): Build with all features

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
   displayName: Build
   inputs:
     projects: '$(runtimeProjects)'
-    arguments: '--configuration $(buildConfiguration)'
+    arguments: '--configuration $(buildConfiguration) -p:DefineConstants=efcore%3Bfluentvalidation%3Bjson%3Bdocker'
 
 
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
Best to put all features. If one is missing the build will never know if
it is valid. For example, if efcore is not set to true then the
migration tool will fail since the `MigrationFactory` will not be in the
compilation