### PR TITLE
feat(WebApi): Use endpoint routing

### DIFF
--- a/CSharp/src/BusinessApp.WebApi/RoutingBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/RoutingBootstrapper.cs
@@ -1,7 +1,6 @@
 ﻿namespace BusinessApp.WebApi
 {
     using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Routing;
     using SimpleInjector;
 
     /// <summary>
@@ -9,37 +8,45 @@
     /// </summary>
     public static class RoutingBootstrapper
     {
-        public static void Bootstrap(Container container, IApplicationBuilder app)
+        public static void SetupEndpoints(this IApplicationBuilder app, Container container)
         {
-            var routeBuilder = new RouteBuilder(app);
+            app.UseRouting();
 
             #region TODO APIS HERE
 
-            //routeBuilder.MapGet("/api/<aggregate>", async ctx =>
-            //    await container
-            //        .GetInstance<IResourceHandler<SomeQuery, IEnumerable<BusinessContract>>>()
-            //        .HandleAsync(ctx, default)
-            //);
-            //routeBuilder.MapGet("/api/<aggregate>/{id:long}", async ctx =>
-            //    await container
-            //        .GetInstance<IResourceHandler<SomeQuery, BusinessContract>>()
-            //        .HandleAsync(ctx, default)
-            //);
-            //routeBuilder.MapPost("/api/<aggregate>", async ctx =>
-            //    await container
-            //        .GetInstance<IResourceHandler<BusinessCommand, BusinessCommand>>()
-            //        .HandleAsync(ctx, default)
-            //);
-            //routeBuilder.MapPut("/api/<aggregate>/{id:long}", async ctx =>
-            //    await container
-            //        .GetInstance<IResourceHandler<BusinessCommand, BusinessCommand>>()
-            //        .HandleAsync(ctx, default)
-            //);
-
+            app.UseEndpoints(endpoint =>
+            {
+                var endpoints = new IEndpointConventionBuilder[]
+                {
+                    //endpoint.MapGet("/api/<aggregate>", async ctx =>
+                    //    await container
+                    //        .GetInstance<IResourceHandler<SomeQuery, IEnumerable<BusinessContract>>>()
+                    //        .HandleAsync(ctx, default)
+                    //),
+                    //endpoint.MapGet("/api/<aggregate>/{id:long}", async ctx =>
+                    //    await container
+                    //        .GetInstance<IResourceHandler<SomeQuery, BusinessContract>>()
+                    //        .HandleAsync(ctx, default)
+                    //),
+                    //endpoint.MapPost("/api/<aggregate>", async ctx =>
+                    //    await container
+                    //        .GetInstance<IResourceHandler<BusinessCommand, BusinessCommand>>()
+                    //        .HandleAsync(ctx, default)
+                    //),
+                    //endpoint.MapPut("/api/<aggregate>/{id:long}", async ctx =>
+                    //    await container
+                    //        .GetInstance<IResourceHandler<BusinessCommand, BusinessCommand>>()
+                    //        .HandleAsync(ctx, default)
+                    //),
+                    //endpoint.MapDelete("/api/<aggregate>/{id:long}", async ctx =>
+                    //    await container
+                    //        .GetInstance<IResourceHandler<DeleteCommand, DeleteCommand>>()
+                    //        .HandleAsync(ctx, default)
+                    //),
+                };
+            });
 
             #endregion
-
-            app.UseRouter(routeBuilder.Build());
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -48,6 +48,8 @@
             app.UseSimpleInjector(container);
             app.UseMiddleware<HttpRequestExceptionMiddleware>(container);
 
+            app.SetupEndpoints(container);
+
             WebApiBootstrapper.Bootstrap(app, env, container);
             container.Verify();
 

--- a/CSharp/src/BusinessApp.WebApi/WebApiBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/WebApiBootstrapper.cs
@@ -41,8 +41,6 @@
                 ctx => !ctx.Handled
             );
 
-            RoutingBootstrapper.Bootstrap(container, app);
-
             return container;
         }
     }


### PR DESCRIPTION
.net recommendation is to use endpoint routing, so remove the route
builder. This allows us to easily use windows authentication on each
endpoint when implemented later

closes [AB#4594](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4594)