### PR TITLE
feat(Serialization): Support dot operator in query string

### DIFF
--- a/CSharp/src/BusinessApp.WebApi.UnitTest/Stubs.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/Stubs.cs
@@ -5,11 +5,6 @@ namespace BusinessApp.WebApi.UnitTest
 
     public enum EnumQueryStub { Foobar }
 
-    public class NestedQueryStub
-    {
-        public string Ipsit { get; set; }
-    }
-
     public class QueryStub
     {
         public bool? Bool { get; set; }
@@ -21,7 +16,20 @@ namespace BusinessApp.WebApi.UnitTest
         public DateTime? DateTime { get; set; }
         public EnumQueryStub? Enum { get; set; }
         public NestedQueryStub SingleNested { get; set; }
+        public DeeplyNestedQueryStub DeeplyNested { get; set; }
         public IEnumerable<NestedQueryStub> MultiNested { get; set; }
         public IEnumerable<float> Enumerable { get; set; }
+
+        public class NestedQueryStub
+        {
+            public string Ipsit { get; set; }
+            public string Dolor { get; set; }
+            public IEnumerable<float> Enumerable { get; set; }
+        }
+
+        public class DeeplyNestedQueryStub
+        {
+            public NestedQueryStub Nested { get; set; }
+        }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/GenericSerializationHelpers.cs
+++ b/CSharp/src/BusinessApp.WebApi/GenericSerializationHelpers.cs
@@ -6,6 +6,7 @@ namespace BusinessApp.WebApi
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.Serialization;
     using System.Web;
     using BusinessApp.App;
     using BusinessApp.Data;
@@ -18,11 +19,9 @@ namespace BusinessApp.WebApi
 
         static GenericSerializationHelpers()
         {
-            var props = typeof(T)
-                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .ToDictionary(prop => prop.Name, prop => prop.PropertyType);
+            propertyCache = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
 
-            propertyCache = new Dictionary<string, Type>(props, StringComparer.OrdinalIgnoreCase);
+            RecurseAllProperties(typeof(T), "");
         }
 
         public static Stream DeserializeUri(HttpContext context, ISerializer serializer)
@@ -40,36 +39,74 @@ namespace BusinessApp.WebApi
             {
                 serializer.Serialize(
                     stream,
-                    collection.AllKeys
+                    CreateDictionary("", collection.AllKeys
                     .Where(key => !string.IsNullOrWhiteSpace(key) && propertyCache.ContainsKey(key))
-                    .ToDictionary(key => key, key =>
-                    {
-                        var val = collection[key];
-
-                        // invalid query string e.g. ?item=foo&&area=bar
-                        if (key == null) return null;
-
-                        var cacheValue = propertyCache[key];
-                        bool isIEnumerable = cacheValue.IsGenericIEnumerable();
-
-                        if (isIEnumerable)
-                        {
-                            var manyItems = val.Contains(',') ? val.Split(',') : new[] { val };
-                            var singItemConverter = TypeDescriptor.GetConverter(
-                                cacheValue.GetGenericArguments()[0]);
-                            return manyItems.Select(i => singItemConverter.ConvertFromInvariantString(i));
-                        }
-
-                        // TODO if they send an ienumerable, but the property is not this will error
-                        var converter = TypeDescriptor.GetConverter(cacheValue);
-                        return converter.ConvertFromInvariantString(val);
-                    })
-                );
+                    .ToDictionary(key => key, key => collection[key])));
 
                 stream.Position = 0;
             }
 
             return stream;
+        }
+
+        private static void RecurseAllProperties(Type type, string prefix)
+        {
+            foreach (var property in type.GetProperties())
+            {
+                var appClass = property.PropertyType.IsClass
+                    && property.PropertyType.Namespace.StartsWith("BusinessApp");
+
+                if (appClass)
+                {
+                    RecurseAllProperties(property.PropertyType, prefix + property.Name + ".");
+                }
+                else
+                {
+                    propertyCache.Add(prefix + property.Name, property.PropertyType);
+                }
+            }
+        }
+
+        private static IDictionary<string, object> CreateDictionary(string prefix,
+            IDictionary<string, string> dictionary)
+        {
+            var data =
+                from kvp in dictionary
+                 let properties = kvp.Key.Split('.')
+                 group kvp by properties[0] into parent
+                 select !parent.First().Key.Contains(".")
+                     ? new KeyValuePair<string, object>(parent.Key,
+                         ConvertStringToType(prefix + parent.Key, parent.First().Value))
+                     : new KeyValuePair<string, object>(parent.Key,
+                         CreateDictionary(prefix + parent.Key + ".", FilterByPropertyName(dictionary, parent.Key)));
+
+            return data.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+        private static object ConvertStringToType(string key, string val)
+        {
+            var cachedType = propertyCache[key];
+            bool isIEnumerable = cachedType.IsGenericIEnumerable();
+
+            if (isIEnumerable)
+            {
+                var manyItems = val.Contains(',') ? val.Split(',') : new[] { val };
+                var singItemConverter = TypeDescriptor.GetConverter(
+                    cachedType.GetGenericArguments()[0]);
+                return manyItems.Select(i => singItemConverter.ConvertFromInvariantString(i));
+            }
+
+            var converter = TypeDescriptor.GetConverter(cachedType);
+            return converter.ConvertFromInvariantString(val);
+        }
+
+        private static IDictionary<string, string> FilterByPropertyName(
+            IDictionary<string, string> dictionary, string propertyName)
+        {
+            string prefix = propertyName + ".";
+            return dictionary.Keys
+                .Where(key => key.StartsWith(prefix))
+                .ToDictionary(key => key.Substring(prefix.Length), key => dictionary[key]);
         }
     }
 }


### PR DESCRIPTION
E.g. foo.bar=lorem or foo.bar.lorem=ipsit, will convert it to dictionary
first to be serialized

fixes [AB#4608](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4608)
closes #26