### PR TITLE
refactor(Config): Remove dotnetenv dependency

### DIFF
--- a/CSharp/.template.config/template.json
+++ b/CSharp/.template.config/template.json
@@ -144,22 +144,11 @@
                 {
                     "condition": "(!docker)",
                     "exclude": [
-                        "src/.env",
                         "src/docker-compose.yml",
                         "src/Dockerfile",
                         "src/docker_run.cmd",
-                        "src/.dockerignore",
-                        "src/BusinessApp.WebApi/.env.docker"
+                        "src/.dockerignore"
                     ]
-                },
-                {
-                    "condition": "(docker)",
-                    "exclude": [
-                        "src/BusinessApp.WebApi/.env"
-                    ],
-                    "rename": {
-                        "src/BusinessApp.WebApi/.env.docker": "src/BusinessApp.WebApi/.env"
-                    }
                 }
             ]
         }

--- a/CSharp/src/BusinessApp.WebApi/.env
+++ b/CSharp/src/BusinessApp.WebApi/.env
@@ -1,3 +1,0 @@
-# TO ONLY BE USED FOR NON PRIVATE DEV VARIABLES!!!!
-
-SQLCONNSTR_BUSINESSAPPLICATION="Server=(localdb)\MSSQLLocalDb;Initial Catalog=BusinessApp;Integrated Security=true"

--- a/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
@@ -14,7 +14,9 @@
     {
         public static readonly Assembly Assembly = typeof(IQuery<>).Assembly;
 
-        public static void Bootstrap(Container container, IWebHostEnvironment env)
+        public static void Bootstrap(Container container,
+            IWebHostEnvironment env,
+            BootstrapOptions options)
         {
             GuardAgainst.Null(container, nameof(container));
 
@@ -39,7 +41,7 @@
             var handlerTypes = container.GetTypesToRegister(typeof(ICommandHandler<>), Assembly);
             container.RegisterCommandHandlersInOneBatch(handlerTypes);
 
-            container.RegisterLoggers(env);
+            container.RegisterLoggers(env, options);
 
             // XXX Order of decorator registration matters.
             // First decorator wraps the real instance

--- a/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
+++ b/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
@@ -1,0 +1,9 @@
+namespace BusinessApp.WebApi
+{
+    public sealed class BootstrapOptions
+    {
+        public string WriteConnectionString { get; set; }
+        public string ReadConnectionString { get; set; }
+        public string LogFilePath { get; set; }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/BusinessApp.WebApi.csproj
+++ b/CSharp/src/BusinessApp.WebApi/BusinessApp.WebApi.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetEnv" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="4.10.3" />
   </ItemGroup>
@@ -24,12 +23,6 @@
     <ProjectReference Include="..\BusinessApp.App\BusinessApp.App.csproj" />
     <ProjectReference Include="..\BusinessApp.Data\BusinessApp.Data.csproj" />
     <ProjectReference Include="..\BusinessApp.Domain\BusinessApp.Domain.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update=".env">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 <!--#if (efcore)-->

--- a/CSharp/src/BusinessApp.WebApi/SimpleInjectorRegistrationExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/SimpleInjectorRegistrationExtensions.cs
@@ -10,7 +10,9 @@ namespace BusinessApp.WebApi
 
     public static class SimpleInjectorRegistrationExtensions
     {
-        public static void RegisterLoggers(this Container container, IWebHostEnvironment env)
+        public static void RegisterLoggers(this Container container,
+            IWebHostEnvironment env,
+            BootstrapOptions options)
         {
             container.Register(typeof(ILogger), typeof(CompositeLogger), Lifestyle.Singleton);
 
@@ -22,8 +24,7 @@ namespace BusinessApp.WebApi
             container.RegisterSingleton<ILogEntryFormatter, SerializedLogEntryFormatter>();
             container.RegisterInstance<IFileProperties>(new RollingFileProperties
             {
-                Name = Environment.GetEnvironmentVariable("BUSINESSAPP_LOG_FILE") ??
-                    $"{env.ContentRootPath}/app.log"
+                Name = options.LogFilePath ?? $"{env.ContentRootPath}/app.log"
             });
 
             container.RegisterSingleton<ConsoleLogger>();

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -31,7 +31,7 @@
             container.Options.DefaultLifestyle = Lifestyle.Scoped;
             container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
 
-            options.LogFilePath = configuration.GetSection("Logginc")
+            options.LogFilePath = configuration.GetSection("Logging")
                 .GetValue<string>("LogFilePath");
             options.WriteConnectionString = options.ReadConnectionString =
                 configuration.GetConnectionString("Main");

--- a/CSharp/src/BusinessApp.WebApi/WebApiBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/WebApiBootstrapper.cs
@@ -14,11 +14,14 @@
     {
         public static readonly Assembly Assembly = typeof(Startup).Assembly;
 
-        public static Container Bootstrap(IApplicationBuilder app, IWebHostEnvironment env, Container container)
+        public static Container Bootstrap(IApplicationBuilder app,
+            IWebHostEnvironment env,
+            Container container,
+            BootstrapOptions options)
         {
             DomainLayerBoostrapper.Bootstrap(container);
-            AppLayerBootstrapper.Bootstrap(container, env);
-            DataLayerBootstrapper.Bootstrap(container);
+            AppLayerBootstrapper.Bootstrap(container, env, options);
+            DataLayerBootstrapper.Bootstrap(container, options);
 
             container.RegisterDecorator(typeof(IResourceHandler<,>), typeof(ResourceNotFoundRequestDecorator<,>));
 

--- a/CSharp/src/BusinessApp.WebApi/appsettings.json
+++ b/CSharp/src/BusinessApp.WebApi/appsettings.json
@@ -1,8 +1,9 @@
 {
     "ConnectionStrings": {
-        "Main": "Server=(localdb)\\MSSQLLocalDb;Initial Catalog=BusinessApp;Integrated Security=true",
 //#if docker
-        "Docker": "Server=172.20.128.2;Initial Catalog=BusinessApp;User Id=sa;Password=foobar123@!3A"
+        "Main": "Server=172.20.128.2;Initial Catalog=BusinessApp;User Id=sa;Password=foobar123@!3A"
+//#else
+        "Main": "Server=(localdb)\\MSSQLLocalDb;Initial Catalog=BusinessApp;Integrated Security=true"
 //#endif
     },
     "Logging": {

--- a/CSharp/src/BusinessApp.WebApi/appsettings.json
+++ b/CSharp/src/BusinessApp.WebApi/appsettings.json
@@ -1,0 +1,16 @@
+{
+    "ConnectionStrings": {
+        "Main": "Server=(localdb)\\MSSQLLocalDb;Initial Catalog=BusinessApp;Integrated Security=true",
+//#if docker
+        "Docker": "Server=172.20.128.2;Initial Catalog=BusinessApp;User Id=sa;Password=foobar123@!3A"
+//#endif
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*"
+}

--- a/CSharp/src/BusinessApp.sln
+++ b/CSharp/src/BusinessApp.sln
@@ -20,7 +20,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Dockerfile = Dockerfile
 		<!--#endif-->
 		.editorconfig = .editorconfig
-		.env = .env
 		.gitignore = .gitignore
 		NuGet.Config = NuGet.Config
 		omnisharp.json = omnisharp.json

--- a/CSharp/src/Dockerfile
+++ b/CSharp/src/Dockerfile
@@ -6,5 +6,4 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
-COPY BusinessApp.WebApi/.env BusinessApp.WebApi/bin/Debug/netcoreapp3.1/publish/ ./
 ENTRYPOINT ["dotnet", "BusinessApp.WebApi.dll"]


### PR DESCRIPTION
Use default configuration provider, which allows different configuration
stores to be used. Map all configurations values to the app
`BootstrapOptions` class so we hide the way we are getting the config
values

fixes [AB#4583](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4583)
closes #31