### PR TITLE
refactor(json): Move serialization classes to App layer

### DIFF
--- a/CSharp/.template.config/template.json
+++ b/CSharp/.template.config/template.json
@@ -138,7 +138,8 @@
                 {
                     "condition": "(!json)",
                     "exclude": [
-                        "src/BusinessApp.WebApi/Json/**"
+                        "src/BusinessApp.WebApi/Json/**",
+                        "src/BusinessApp.App/Json/**"
                     ]
                 },
                 {

--- a/CSharp/src/BusinessApp.App/BusinessApp.App.csproj
+++ b/CSharp/src/BusinessApp.App/BusinessApp.App.csproj
@@ -9,6 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
+<!--#if (json)-->
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+<!--#endif-->
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
 <!--#if (fluentvalidation)-->
     <PackageReference Include="FluentValidation" Version="8.6.2" />

--- a/CSharp/src/BusinessApp.App/Json/EntityIdJsonConverter.cs
+++ b/CSharp/src/BusinessApp.App/Json/EntityIdJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace BusinessApp.WebApi.Json
+﻿namespace BusinessApp.App.Json
 {
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;

--- a/CSharp/src/BusinessApp.App/Json/LongToStringJsonConverter.cs
+++ b/CSharp/src/BusinessApp.App/Json/LongToStringJsonConverter.cs
@@ -1,4 +1,4 @@
-namespace BusinessApp.WebApi.Json
+namespace BusinessApp.App.Json
 {
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;

--- a/CSharp/src/BusinessApp.App/Json/NewtonsoftJsonSerializer.cs
+++ b/CSharp/src/BusinessApp.App/Json/NewtonsoftJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿namespace BusinessApp.WebApi.Json
+﻿namespace BusinessApp.App.Json
 {
     using System.IO;
     using System.Text;
@@ -6,13 +6,13 @@
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Default json serializer
+    /// A json serializer based on Newtonsoft
     /// </summary>
-    public class JsonFormatter : ISerializer
+    public class NewtonsoftJsonSerializer : ISerializer
     {
         private readonly JsonSerializer serializer;
 
-        public JsonFormatter(JsonSerializerSettings settings)
+        public NewtonsoftJsonSerializer(JsonSerializerSettings settings)
         {
             serializer = JsonSerializer.Create(settings);
         }

--- a/CSharp/src/BusinessApp.WebApi/Json/Bootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/Bootstrapper.cs
@@ -1,6 +1,7 @@
 ﻿namespace BusinessApp.WebApi.Json
 {
     using BusinessApp.App;
+    using BusinessApp.App.Json;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
     using SimpleInjector;
@@ -13,7 +14,7 @@
         public static void Bootstrap(Container container)
         {
             container.RegisterDecorator(typeof(IResourceHandler<,>), typeof(JsonResponseDecorator<,>));
-            container.RegisterSingleton<ISerializer, JsonFormatter>();
+            container.RegisterSingleton<ISerializer, NewtonsoftJsonSerializer>();
 
             container.RegisterInstance(
                 new JsonSerializerSettings


### PR DESCRIPTION
Rename JsonFormatter to more specific name based on implementation.
Other classes have no reason to be in the web layer

fixes [AB#4599](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4599)