### PR TITLE
fix(serialization): Use BodyReader

### DIFF
--- a/CSharp/src/BusinessApp.WebApi/CommandResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/CommandResourceHandler.cs
@@ -26,7 +26,7 @@
 
         public async Task<TRequest> HandleAsync(HttpContext context, CancellationToken cancellationToken)
         {
-            var command = context.DeserializeInto<TRequest>(serializer);
+            var command = await context.DeserializeIntoAsync<TRequest>(serializer, cancellationToken);
 
             if (command == null)
             {

--- a/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
@@ -25,7 +25,7 @@ namespace BusinessApp.WebApi
 
         public async Task<IEnumerable<TResponse>> HandleAsync(HttpContext context, CancellationToken cancellationToken)
         {
-            var query = context.DeserializeInto<TRequest>(serializer);
+            var query = await context.DeserializeIntoAsync<TRequest>(serializer, cancellationToken);
 
             if (query == null)
             {

--- a/CSharp/src/BusinessApp.WebApi/QueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/QueryResourceHandler.cs
@@ -26,7 +26,7 @@
         public async Task<TResponse> HandleAsync(HttpContext context,
             CancellationToken cancellationToken)
         {
-            var query = context.DeserializeInto<TRequest>(serializer);
+            var query = await context.DeserializeIntoAsync<TRequest>(serializer, cancellationToken);
 
             if (query == null)
             {


### PR DESCRIPTION
* .net 3.0 throws if you use Sync IO without explicitly setting a flag.
  Change to async reading on body reader to pass to sync serialization.
  BodyReader is the future and recommended approach.