### PR TITLE
test: Remove DummyCommand, Repace with CommandStub

### DIFF
--- a/CSharp/src/BusinessApp.App.UnitTest/BatchCommandHandlerTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/BatchCommandHandlerTests.cs
@@ -12,15 +12,15 @@ namespace BusinessApp.App.UnitTest
     public class BatchCommandHandlerTests
     {
         private readonly CancellationToken token;
-        private readonly BatchCommandHandler<DummyCommand> sut;
-        private readonly ICommandHandler<DummyCommand> inner;
+        private readonly BatchCommandHandler<CommandStub> sut;
+        private readonly ICommandHandler<CommandStub> inner;
 
         public BatchCommandHandlerTests()
         {
             token = A.Dummy<CancellationToken>();
-            inner = A.Fake<ICommandHandler<DummyCommand>>();
+            inner = A.Fake<ICommandHandler<CommandStub>>();
 
-            sut = new BatchCommandHandler<DummyCommand>(inner);
+            sut = new BatchCommandHandler<CommandStub>(inner);
         }
 
         public class Constructor : BatchCommandHandlerTests
@@ -31,10 +31,10 @@ namespace BusinessApp.App.UnitTest
             };
 
             [Theory, MemberData(nameof(InvalidCtorArgs))]
-            public void InvalidCtorArgs_ExceptionThrown(ICommandHandler<DummyCommand> c)
+            public void InvalidCtorArgs_ExceptionThrown(ICommandHandler<CommandStub> c)
             {
                 /* Arrange */
-                void shouldThrow() => new BatchCommandHandler<DummyCommand>(c);
+                void shouldThrow() => new BatchCommandHandler<CommandStub>(c);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -63,7 +63,7 @@ namespace BusinessApp.App.UnitTest
             public async Task WithCommands_EachCalled()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 /* Act */
                 await sut.HandleAsync(commands, token);
@@ -77,7 +77,7 @@ namespace BusinessApp.App.UnitTest
             public async Task ExceptionThrown_IndexAddedToDataKey()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
                 var thrownException = new Exception();
                 thrownException.Data.Add("foo", "bar");
 
@@ -104,7 +104,7 @@ namespace BusinessApp.App.UnitTest
             public async Task WithInnerExceptions_IndexAddedToInnerException()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
                 var thrownInner = new Exception("foo");
                 var thrownException = new Exception("bar", thrownInner);
                 thrownException.Data.Add("lorem", "ipsum");
@@ -133,7 +133,7 @@ namespace BusinessApp.App.UnitTest
             public async Task MultipleExceptions_AggregateExceptionThrown()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
                 var firstEx = new Exception("ispit");
                 var secondEx = new Exception("ispit");
                 firstEx.Data.Add("foo", "bar");

--- a/CSharp/src/BusinessApp.App.UnitTest/DeadlockRetryDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/DeadlockRetryDecoratorTests.cs
@@ -12,15 +12,15 @@ namespace BusinessApp.App.UnitTest
     public class DeadlockRetryDecoratorTests
     {
         private readonly CancellationToken token;
-        private readonly DeadlockRetryDecorator<DummyCommand> sut;
-        private readonly ICommandHandler<DummyCommand> inner;
+        private readonly DeadlockRetryDecorator<CommandStub> sut;
+        private readonly ICommandHandler<CommandStub> inner;
 
         public DeadlockRetryDecoratorTests()
         {
             token = A.Dummy<CancellationToken>();
-            inner = A.Fake<ICommandHandler<DummyCommand>>();
+            inner = A.Fake<ICommandHandler<CommandStub>>();
 
-            sut = new DeadlockRetryDecorator<DummyCommand>(inner);
+            sut = new DeadlockRetryDecorator<CommandStub>(inner);
         }
 
         public class Constructor : DeadlockRetryDecoratorTests
@@ -34,10 +34,10 @@ namespace BusinessApp.App.UnitTest
             };
 
             [Theory, MemberData(nameof(InvalidCtorArgs))]
-            public void InvalidCtorArgs_ExceptionThrown(ICommandHandler<DummyCommand> c)
+            public void InvalidCtorArgs_ExceptionThrown(ICommandHandler<CommandStub> c)
             {
                 /* Arrange */
-                void shouldThrow() => new DeadlockRetryDecorator<DummyCommand>(c);
+                void shouldThrow() => new DeadlockRetryDecorator<CommandStub>(c);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -54,7 +54,7 @@ namespace BusinessApp.App.UnitTest
             public async Task NormalException_DoesNothing()
             {
                 /* Arrange */
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
                 A.CallTo(() => inner.HandleAsync(command, token)).Throws<Exception>();
 
                 /* Act */
@@ -68,7 +68,7 @@ namespace BusinessApp.App.UnitTest
             public async Task DbExceptionNotADeadlock_DoesNothing()
             {
                 /* Arrange */
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
                 var exception = A.Fake<DbException>();
                 A.CallTo(() => inner.HandleAsync(command, token)).Throws(exception);
 
@@ -83,7 +83,7 @@ namespace BusinessApp.App.UnitTest
             public async Task DbExceptionIsDeadlock_Retries5times()
             {
                 /* Arrange */
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
                 var exception = A.Fake<DbException>();
                 A.CallTo(() => exception.Message).Returns("foobar deadlock lorem");
                 A.CallTo(() => inner.HandleAsync(command, token)).Throws(exception).NumberOfTimes(4);
@@ -100,7 +100,7 @@ namespace BusinessApp.App.UnitTest
             public async Task DbExceptionIsDeadlockAfterFiveTimes_ThrowsCommunicationException()
             {
                 /* Arrange */
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
                 var exception = A.Fake<DbException>();
                 A.CallTo(() => exception.Message).Returns("foobar deadlock lorem");
                 A.CallTo(() => inner.HandleAsync(command, token)).Throws(exception).NumberOfTimes(5);
@@ -121,7 +121,7 @@ namespace BusinessApp.App.UnitTest
             public async Task DbExceptionInInnerExceptionIsDeadlock_Retries5times()
             {
                 /* Arrange */
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
                 var dbException = A.Fake<DbException>();
                 A.CallTo(() => dbException.Message).Returns("foobar deadlock lorem");
                 var exception = new Exception("foo", new Exception("bar", dbException));

--- a/CSharp/src/BusinessApp.App.UnitTest/NullBatchGrouperTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/NullBatchGrouperTests.cs
@@ -8,13 +8,13 @@ namespace BusinessApp.App.UnitTest
     public class NullBatchGrouperTests
     {
         private readonly CancellationToken token;
-        private readonly NullBatchGrouper<DummyCommand> sut;
+        private readonly NullBatchGrouper<CommandStub> sut;
 
         public NullBatchGrouperTests()
         {
             token = A.Dummy<CancellationToken>();
 
-            sut = new NullBatchGrouper<DummyCommand>();
+            sut = new NullBatchGrouper<CommandStub>();
         }
 
         public class GroupAsync : NullBatchGrouperTests
@@ -23,7 +23,7 @@ namespace BusinessApp.App.UnitTest
             public async Task DefaultBehavior_OneGroupReturned()
             {
                 /* Arrange */
-                var commands = new[] { new DummyCommand(), new DummyCommand() };
+                var commands = new[] { new CommandStub(), new CommandStub() };
 
                 /* Act */
                 var grouping = await sut.GroupAsync(commands, token);

--- a/CSharp/src/BusinessApp.App.UnitTest/Stubs.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/Stubs.cs
@@ -5,9 +5,6 @@ namespace BusinessApp.App.UnitTest
     public class CommandStub
     {}
 
-    [System.Obsolete("Use CommandStub instead")]
-    public class DummyCommand { }
-
     [Authorize]
     public class AuthCommandStub : CommandStub
     {}

--- a/CSharp/src/BusinessApp.App.UnitTest/TransactionDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/TransactionDecoratorTests.cs
@@ -10,18 +10,18 @@ namespace BusinessApp.App.UnitTest
 
     public class TransactionDecoratorTests
     {
-        private readonly TransactionDecorator<DummyCommand> sut;
-        private readonly ICommandHandler<DummyCommand> inner;
+        private readonly TransactionDecorator<CommandStub> sut;
+        private readonly ICommandHandler<CommandStub> inner;
         private readonly ITransactionFactory factory;
         private readonly PostCommitRegister register;
 
         public TransactionDecoratorTests()
         {
-            inner = A.Fake<ICommandHandler<DummyCommand>>();
+            inner = A.Fake<ICommandHandler<CommandStub>>();
             factory = A.Fake<ITransactionFactory>();
             register = new PostCommitRegister();
 
-            sut = new TransactionDecorator<DummyCommand>(factory, inner, register);
+            sut = new TransactionDecorator<CommandStub>(factory, inner, register);
         }
 
         public class Constructor : TransactionDecoratorTests
@@ -31,7 +31,7 @@ namespace BusinessApp.App.UnitTest
                 new object[]
                 {
                     null,
-                    A.Dummy<ICommandHandler<DummyCommand>>(),
+                    A.Dummy<ICommandHandler<CommandStub>>(),
                     A.Dummy<PostCommitRegister>()
                 },
                 new object[]
@@ -43,17 +43,17 @@ namespace BusinessApp.App.UnitTest
                 new object[]
                 {
                     A.Fake<ITransactionFactory>(),
-                    A.Dummy<ICommandHandler<DummyCommand>>(),
+                    A.Dummy<ICommandHandler<CommandStub>>(),
                     null,
                 },
             };
 
             [Theory, MemberData(nameof(InvalidCtorArgs))]
             public void InvalidCtorArgs_ExceptionThrown(ITransactionFactory v,
-                ICommandHandler<DummyCommand> c, PostCommitRegister r)
+                ICommandHandler<CommandStub> c, PostCommitRegister r)
             {
                 /* Arrange */
-                void shouldThrow() => new TransactionDecorator<DummyCommand>(v, c, r);
+                void shouldThrow() => new TransactionDecorator<CommandStub>(v, c, r);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -83,7 +83,7 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 var token = A.Dummy<CancellationToken>();
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
                 var uow = A.Fake<IUnitOfWork>();
                 A.CallTo(() => factory.Begin()).Returns(uow);
 
@@ -109,7 +109,7 @@ namespace BusinessApp.App.UnitTest
                 A.CallTo(() => factory.Begin()).Returns(uow);
 
                 /* Act */
-                await sut.HandleAsync(A.Dummy<DummyCommand>(), token);
+                await sut.HandleAsync(A.Dummy<CommandStub>(), token);
 
                 /* Assert */
                 A.CallTo(() => handler1()).MustHaveHappenedOnceExactly()
@@ -131,7 +131,7 @@ namespace BusinessApp.App.UnitTest
                 register.FinishHandlers.Add(handler2);
 
                 /* Act */
-                var ex = await Record.ExceptionAsync(() => sut.HandleAsync(A.Dummy<DummyCommand>(), token));
+                var ex = await Record.ExceptionAsync(() => sut.HandleAsync(A.Dummy<CommandStub>(), token));
 
                 /* Assert */
                 Assert.NotNull(ex);
@@ -154,7 +154,7 @@ namespace BusinessApp.App.UnitTest
                 register.FinishHandlers.Add(handler1);
 
                 /* Act */
-                var ex = await Record.ExceptionAsync(() => sut.HandleAsync(A.Dummy<DummyCommand>(), token));
+                var ex = await Record.ExceptionAsync(() => sut.HandleAsync(A.Dummy<CommandStub>(), token));
 
                 /* Assert */
                 Assert.IsType<CommunicationException>(ex);

--- a/CSharp/src/BusinessApp.App.UnitTest/ValidationBatchCommandDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/ValidationBatchCommandDecoratorTests.cs
@@ -11,34 +11,34 @@ namespace BusinessApp.App.UnitTest
     public class ValidationBatchCommandDecoratorTests
     {
         private readonly CancellationToken token;
-        private readonly ValidationBatchCommandDecorator<DummyCommand> sut;
-        private readonly ICommandHandler<IEnumerable<DummyCommand>> inner;
-        private readonly IValidator<DummyCommand> validator;
+        private readonly ValidationBatchCommandDecorator<CommandStub> sut;
+        private readonly ICommandHandler<IEnumerable<CommandStub>> inner;
+        private readonly IValidator<CommandStub> validator;
 
         public ValidationBatchCommandDecoratorTests()
         {
             token = A.Dummy<CancellationToken>();
-            inner = A.Fake<ICommandHandler<IEnumerable<DummyCommand>>>();
-            validator = A.Fake<IValidator<DummyCommand>>();
+            inner = A.Fake<ICommandHandler<IEnumerable<CommandStub>>>();
+            validator = A.Fake<IValidator<CommandStub>>();
 
-            sut = new ValidationBatchCommandDecorator<DummyCommand>(validator, inner);
+            sut = new ValidationBatchCommandDecorator<CommandStub>(validator, inner);
         }
 
         public class Constructor : ValidationBatchCommandDecoratorTests
         {
             public static IEnumerable<object[]> InvalidCtorArgs => new[]
             {
-                new object[] { null, A.Dummy<ICommandHandler<IEnumerable<DummyCommand>>>() },
-                new object[] { A.Fake<IValidator<DummyCommand>>(), null },
+                new object[] { null, A.Dummy<ICommandHandler<IEnumerable<CommandStub>>>() },
+                new object[] { A.Fake<IValidator<CommandStub>>(), null },
             };
 
             [Theory, MemberData(nameof(InvalidCtorArgs))]
             public void InvalidCtorArgs_ExceptionThrown(
-                IValidator<DummyCommand> v,
-                ICommandHandler<IEnumerable<DummyCommand>> c)
+                IValidator<CommandStub> v,
+                ICommandHandler<IEnumerable<CommandStub>> c)
             {
                 /* Arrange */
-                void shouldThrow() => new ValidationBatchCommandDecorator<DummyCommand>(v, c);
+                void shouldThrow() => new ValidationBatchCommandDecorator<CommandStub>(v, c);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -68,8 +68,8 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 var handlerCallsBeforeValidate = 0;
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
-                A.CallTo(() => validator.ValidateAsync(A<DummyCommand>._, token))
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
+                A.CallTo(() => validator.ValidateAsync(A<CommandStub>._, token))
                     .Invokes(ctx => handlerCallsBeforeValidate += Fake.GetCalls(inner).Count());
 
                 /* Act */
@@ -83,7 +83,7 @@ namespace BusinessApp.App.UnitTest
             public async Task WithTwoCommands_ValidatedTwice()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 /* Act */
                 await sut.HandleAsync(commands, token);
@@ -99,7 +99,7 @@ namespace BusinessApp.App.UnitTest
             public async Task WithTwoCommands_HandledOnce()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 /* Act */
                 await sut.HandleAsync(commands, token);
@@ -113,7 +113,7 @@ namespace BusinessApp.App.UnitTest
             public async Task ValidationException_MemberNameHasIndex()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 A.CallTo(() => validator.ValidateAsync(commands.Last(), token))
                     .Throws(new ValidationException("foo", "bar"));
@@ -131,7 +131,7 @@ namespace BusinessApp.App.UnitTest
             public async Task ValidationException_SameMessageUsed()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 A.CallTo(() => validator.ValidateAsync(commands.First(), token))
                     .Throws(new ValidationException("foo", "bar"));
@@ -148,7 +148,7 @@ namespace BusinessApp.App.UnitTest
             public async Task ValidationException_InnerExceptionUsed()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
                 var innerException = new ValidationException("lorem", "ipsum");
 
                 A.CallTo(() => validator.ValidateAsync(commands.Last(), token))
@@ -166,7 +166,7 @@ namespace BusinessApp.App.UnitTest
             public async Task AggregateException_HasMultipleValidationExceptions()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 A.CallTo(() => validator.ValidateAsync(commands.Last(), token))
                     .Throws(new AggregateException(new[]
@@ -187,7 +187,7 @@ namespace BusinessApp.App.UnitTest
             public async Task AggregateException_MemberNamesHasIndex()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 A.CallTo(() => validator.ValidateAsync(commands.Last(), token))
                     .Throws(new AggregateException(new[]
@@ -211,7 +211,7 @@ namespace BusinessApp.App.UnitTest
             public async Task AggregateException_SameMessageUsed()
             {
                 /* Arrange */
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 A.CallTo(() => validator.ValidateAsync(commands.Last(), token))
                     .Throws(new AggregateException(new[]
@@ -237,7 +237,7 @@ namespace BusinessApp.App.UnitTest
                 /* Arrange */
                 var firstInner = new Exception();
                 var secondInner = new Exception();
-                var commands = new[] { A.Dummy<DummyCommand>(), A.Dummy<DummyCommand>() };
+                var commands = new[] { A.Dummy<CommandStub>(), A.Dummy<CommandStub>() };
 
                 A.CallTo(() => validator.ValidateAsync(commands.Last(), token))
                     .Throws(new AggregateException(new[]

--- a/CSharp/src/BusinessApp.App.UnitTest/ValidationCommandDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/ValidationCommandDecoratorTests.cs
@@ -12,34 +12,34 @@ namespace BusinessApp.App.UnitTest
     public class ValidationCommandDecoratorTests
     {
         private readonly CancellationToken token;
-        private readonly ValidationCommandDecorator<DummyCommand> sut;
-        private readonly ICommandHandler<DummyCommand> inner;
-        private readonly IValidator<DummyCommand> validator;
+        private readonly ValidationCommandDecorator<CommandStub> sut;
+        private readonly ICommandHandler<CommandStub> inner;
+        private readonly IValidator<CommandStub> validator;
 
         public ValidationCommandDecoratorTests()
         {
             token = A.Dummy<CancellationToken>();
-            inner = A.Fake<ICommandHandler<DummyCommand>>();
-            validator = A.Fake<IValidator<DummyCommand>>();
+            inner = A.Fake<ICommandHandler<CommandStub>>();
+            validator = A.Fake<IValidator<CommandStub>>();
 
-            sut = new ValidationCommandDecorator<DummyCommand>(validator, inner);
+            sut = new ValidationCommandDecorator<CommandStub>(validator, inner);
         }
 
         public class Constructor : ValidationCommandDecoratorTests
         {
             public static IEnumerable<object[]> InvalidCtorArgs => new[]
             {
-                new object[] { null, A.Dummy<ICommandHandler<DummyCommand>>() },
-                new object[] { A.Fake<IValidator<DummyCommand>>(), null },
+                new object[] { null, A.Dummy<ICommandHandler<CommandStub>>() },
+                new object[] { A.Fake<IValidator<CommandStub>>(), null },
             };
 
             [Theory, MemberData(nameof(InvalidCtorArgs))]
             public void InvalidCtorArgs_ExceptionThrown(
-                IValidator<DummyCommand> v,
-                ICommandHandler<DummyCommand> c)
+                IValidator<CommandStub> v,
+                ICommandHandler<CommandStub> c)
             {
                 /* Arrange */
-                void shouldThrow() => new ValidationCommandDecorator<DummyCommand>(v, c);
+                void shouldThrow() => new ValidationCommandDecorator<CommandStub>(v, c);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -69,8 +69,8 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 var handlerCallsBeforeValidate = 0;
-                var command = A.Dummy<DummyCommand>();
-                A.CallTo(() => validator.ValidateAsync(A<DummyCommand>._, token))
+                var command = A.Dummy<CommandStub>();
+                A.CallTo(() => validator.ValidateAsync(A<CommandStub>._, token))
                     .Invokes(ctx => handlerCallsBeforeValidate += Fake.GetCalls(inner).Count());
 
                 /* Act */
@@ -84,7 +84,7 @@ namespace BusinessApp.App.UnitTest
             public async Task WithCommand_ValidatedOnce()
             {
                 /* Arrange */
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
 
                 /* Act */
                 await sut.HandleAsync(command, token);
@@ -99,7 +99,7 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 var token = A.Dummy<CancellationToken>();
-                var command = A.Dummy<DummyCommand>();
+                var command = A.Dummy<CommandStub>();
 
 
                 /* Act */


### PR DESCRIPTION
Dummies are basically placeholders, and we should use FakeItEasy syntax.
stubs may have some meaningful data, or they can represent a dummy
placeholder in the test

fixes [AB#4799](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/4799)