### PR TITLE
fix(bootstrap): Fix webapi registrations

### DIFF
--- a/CSharp/src/BusinessApp.Test.Common/DatabaseFixture.cs
+++ b/CSharp/src/BusinessApp.Test.Common/DatabaseFixture.cs
@@ -36,7 +36,7 @@ namespace BusinessApp.Test
                 .Services
                 .GetService(typeof(IConfiguration));
 
-            ConnectionStr = config.GetConnectionString("sqlserver");
+            ConnectionStr = config.GetConnectionString("local");
 		}
 
 		public DatabaseFixture()

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/AppLayerBootstrapperTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/AppLayerBootstrapperTests.cs
@@ -16,6 +16,7 @@ namespace BusinessApp.WebApi.IntegrationTest
     using SimpleInjector.Lifestyles;
     using BusinessApp.Domain;
     using Microsoft.Extensions.Configuration;
+    using BusinessApp.Data;
 
     public class AppLayerBootstrapperTests
     {

--- a/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
@@ -152,6 +152,11 @@
                 },
                 Lifestyle.Scoped,
                 c => !c.Handled);
+
+            container.RegisterConditional(
+                typeof(IRequestHandler<,>),
+                typeof(SingleQueryHandlerDelegator<,>),
+                ctx => !ctx.Handled);
         }
 
         private static bool HasTransactionScope(DecoratorPredicateContext ctx)

--- a/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
@@ -38,13 +38,11 @@
 #endif
             container.Register(typeof(IAuthorizer<>), typeof(AuthorizeAttributeHandler<>));
 
-#if batch
             container.Register(typeof(IBatchGrouper<>), options.AppLayerAssembly);
             container.Register(typeof(IBatchMacro<,>), options.AppLayerAssembly);
             container.RegisterConditional(typeof(IBatchGrouper<>),
                 typeof(NullBatchGrouper<>),
                 ctx => !ctx.Handled);
-#endif
 
             container.RegisterLoggers(env, options);
 

--- a/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
@@ -33,7 +33,7 @@
             container.Register(typeof(IValidator<>), typeof(CompositeValidator<>), Lifestyle.Singleton);
 
 #if fluentvalidation
-            container.Collection.Register(typeof(FluentValidation.IValidator<>), options.AppLayerAssembly);
+            container.Collection.Register(typeof(FluentValidation.IValidator<>), options.AppAssemblies);
             container.Collection.Append(typeof(IValidator<>), typeof(FluentValidationValidator<>));
 #endif
             container.Register(typeof(IAuthorizer<>), typeof(AuthorizeAttributeHandler<>));

--- a/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
@@ -27,7 +27,7 @@
 
             var registrations = new[] { typeof(DataAnnotationsValidator<>) }.Concat(container.GetTypesToRegister(
                 typeof(IValidator<>),
-                new[] { options.AppLayerAssembly }
+                options.AppAssemblies
             ));
             container.Collection.Register(typeof(IValidator<>), registrations);
             container.Register(typeof(IValidator<>), typeof(CompositeValidator<>), Lifestyle.Singleton);
@@ -38,8 +38,8 @@
 #endif
             container.Register(typeof(IAuthorizer<>), typeof(AuthorizeAttributeHandler<>));
 
-            container.Register(typeof(IBatchGrouper<>), options.AppLayerAssembly);
-            container.Register(typeof(IBatchMacro<,>), options.AppLayerAssembly);
+            container.Register(typeof(IBatchMacro<,>), options.AppAssemblies);
+            container.Register(typeof(IBatchGrouper<>), options.AppAssemblies);
             container.RegisterConditional(typeof(IBatchGrouper<>),
                 typeof(NullBatchGrouper<>),
                 ctx => !ctx.Handled);
@@ -49,7 +49,7 @@
             IEnumerable<Type> GetTypesToRegister()
             {
                 return container.GetTypesToRegister(typeof(IRequestHandler<,>),
-                    new[] { options.AppLayerAssembly },
+                    options.AppAssemblies,
                     new TypesToRegisterOptions
                     {
                         IncludeGenericTypeDefinitions = true,

--- a/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/AppLayerBootstrapper.cs
@@ -38,15 +38,16 @@
 #endif
             container.Register(typeof(IAuthorizer<>), typeof(AuthorizeAttributeHandler<>));
 
+#if batch
             container.Register(typeof(IBatchGrouper<>), options.AppLayerAssembly);
             container.Register(typeof(IBatchMacro<,>), options.AppLayerAssembly);
             container.RegisterConditional(typeof(IBatchGrouper<>),
                 typeof(NullBatchGrouper<>),
                 ctx => !ctx.Handled);
+#endif
 
             container.RegisterLoggers(env, options);
 
-#if batch
             IEnumerable<Type> GetTypesToRegister()
             {
                 return container.GetTypesToRegister(typeof(IRequestHandler<,>),
@@ -107,7 +108,6 @@
 #if efcore
             container.RegisterQueryDecorator(typeof(EFTrackingQueryDecorator<,>));
 #endif
-#if batch
             container.RegisterDecorator(
                 typeof(IRequestHandler<,>),
                 typeof(RequestExceptionDecorator<,>),

--- a/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
+++ b/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
@@ -1,11 +1,13 @@
 namespace BusinessApp.WebApi
 {
+    using System.Collections.Generic;
     using System.Reflection;
 
     public sealed class BootstrapOptions
     {
         public string DbConnectionString { get; set; }
         public string LogFilePath { get; set; }
-        public Assembly AppLayerAssembly { get; set; }
+        public IEnumerable<Assembly> AppAssemblies { get; set; }
+        public IEnumerable<Assembly> DataAssemblies { get; set; }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
+++ b/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
@@ -1,9 +1,11 @@
 namespace BusinessApp.WebApi
 {
+    using System.Reflection;
+
     public sealed class BootstrapOptions
     {
-        public string WriteConnectionString { get; set; }
-        public string ReadConnectionString { get; set; }
+        public string DbConnectionString { get; set; }
         public string LogFilePath { get; set; }
+        public Assembly AppLayerAssembly { get; set; }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/DataLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/DataLayerBootstrapper.cs
@@ -76,7 +76,7 @@
             container.Register<IUnitOfWork>(() => container.GetInstance<EFUnitOfWork>());
             container.Register<ITransactionFactory>(() => container.GetInstance<EFUnitOfWork>());
 
-            RegisterDbContext<BusinessAppDbContext>(container, options.WriteConnectionString);
+            RegisterDbContext<BusinessAppDbContext>(container, options.DbConnectionString);
 #else
             container.Register<ITransactionFactory, NullTransactionFactory>();
 #endif

--- a/CSharp/src/BusinessApp.WebApi/DataLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/DataLayerBootstrapper.cs
@@ -9,7 +9,6 @@
     using Microsoft.Extensions.Logging;
 //#endif
 #endif
-    using System.Reflection;
     using BusinessApp.Data;
     using BusinessApp.Domain;
     using BusinessApp.App;
@@ -19,7 +18,6 @@
     /// </summary>
     public static class DataLayerBootstrapper
     {
-        public static readonly Assembly Assembly = typeof(IQueryVisitor<>).Assembly;
 #if efcore
 //#if DEBUG
         public static readonly ILoggerFactory DataLayerLoggerFactory
@@ -41,8 +39,8 @@
 
             container.Register(typeof(IQueryVisitorFactory<,>), typeof(CompositeQueryVisitorBuilder<,>));
             container.Register(typeof(ILinqSpecificationBuilder<,>), typeof(AndSpecificationBuilder<,>));
-            container.Collection.Register(typeof(ILinqSpecificationBuilder<,>), Assembly);
-            container.Collection.Register(typeof(IQueryVisitor<>), Assembly);
+            container.Collection.Register(typeof(ILinqSpecificationBuilder<,>), options.DataAssemblies);
+            container.Collection.Register(typeof(IQueryVisitor<>), options.DataAssemblies);
             container.RegisterConditional(
                 typeof(IQueryVisitor<>),
                 typeof(NullQueryVisitor<>), ctx => !ctx.Handled);
@@ -57,7 +55,7 @@
             });
 #if efcore
             container.Register(typeof(IDatastore<>), typeof(EFDatastore<>));
-            container.Register(typeof(IDbSetVisitorFactory<,>), Assembly);
+            container.Register(typeof(IDbSetVisitorFactory<,>), options.DataAssemblies);
             container.RegisterConditional(
                 typeof(IDbSetVisitorFactory<,>),
                 typeof(NullDbSetVisitorFactory<,>),

--- a/CSharp/src/BusinessApp.WebApi/DomainLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/DomainLayerBootstrapper.cs
@@ -3,6 +3,7 @@
     using SimpleInjector;
     using System.Reflection;
     using BusinessApp.Domain;
+    using System.Linq;
 
     /// <summary>
     /// Allows registering all types that are defined in the domain layer
@@ -18,10 +19,8 @@
             container.Collection.Register(typeof(IEventHandler<>), new[]
             {
                 Assembly,
-                options.AppLayerAssembly,
-                DataLayerBootstrapper.Assembly,
                 WebApiBootstrapper.Assembly
-            });
+            }.Concat(options.AppAssemblies).Concat(options.DataAssemblies));
 
             container.Collection.Append(typeof(IEventHandler<>), typeof(DomainEventHandler<>));
             container.Register<EventUnitOfWork>();

--- a/CSharp/src/BusinessApp.WebApi/DomainLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/DomainLayerBootstrapper.cs
@@ -11,14 +11,14 @@
     {
         private static readonly Assembly Assembly = typeof(IEventHandler<>).Assembly;
 
-        public static void Bootstrap(Container container)
+        public static void Bootstrap(Container container, BootstrapOptions options)
         {
             Guard.Against.Null(container).Expect(nameof(container));
 
             container.Collection.Register(typeof(IEventHandler<>), new[]
             {
                 Assembly,
-                AppLayerBootstrapper.Assembly,
+                options.AppLayerAssembly,
                 DataLayerBootstrapper.Assembly,
                 WebApiBootstrapper.Assembly
             });

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -41,7 +41,8 @@
 #else
                 configuration.GetConnectionString("local");
 #endif
-            options.AppLayerAssembly = typeof(App.IQuery).Assembly;
+            options.AppAssemblies = new[] { typeof(App.IQuery).Assembly };
+            options.DataAssemblies = new[] { typeof(IQueryVisitor<>).Assembly };
         }
 
         // This method gets called by the runtime. Use this method to add services to the container.

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -16,7 +16,7 @@
 #endif
 //#if DEBUG
     using Microsoft.Extensions.Logging;
-    //#endif
+//#endif
 #if winauth
     using Microsoft.AspNetCore.Server.HttpSys;
 #endif
@@ -35,12 +35,13 @@
 
             options.LogFilePath = configuration.GetSection("Logging")
                 .GetValue<string>("LogFilePath");
-            options.WriteConnectionString = options.ReadConnectionString =
+            options.DbConnectionString =
 #if docker
                 configuration.GetConnectionString("docker");
 #else
                 configuration.GetConnectionString("local");
 #endif
+            options.AppLayerAssembly = typeof(App.IQuery).Assembly;
         }
 
         // This method gets called by the runtime. Use this method to add services to the container.

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -11,9 +11,7 @@
     using SimpleInjector;
     using SimpleInjector.Lifestyles;
     using System;
-#if efcore
     using BusinessApp.Data;
-#endif
 //#if DEBUG
     using Microsoft.Extensions.Logging;
 //#endif

--- a/CSharp/src/BusinessApp.WebApi/WebApiBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/WebApiBootstrapper.cs
@@ -25,13 +25,7 @@
             Container container,
             BootstrapOptions options)
         {
-            // TODO need to register prior to Data layer. Probabl should put
-            // all request handling in one bootstrap file instead of layers
-            container.RegisterConditional(
-                typeof(IRequestHandler<,>),
-                typeof(SingleQueryHandlerDelegator<,>),
-                ctx => ctx.Handled);
-            DomainLayerBoostrapper.Bootstrap(container);
+            DomainLayerBoostrapper.Bootstrap(container, options);
             DataLayerBootstrapper.Bootstrap(container, options);
             AppLayerBootstrapper.Bootstrap(container, env, options);
 

--- a/CSharp/src/BusinessApp.WebApi/appsettings.test.json
+++ b/CSharp/src/BusinessApp.WebApi/appsettings.test.json
@@ -1,5 +1,5 @@
 {
     "ConnectionStrings": {
-        "sqlserver": "Server=(localdb)\\MSSQLLocalDb;Initial Catalog=BusinessApp_Test;Integrated Security=true"
+        "local": "Server=(localdb)\\MSSQLLocalDb;Initial Catalog=BusinessApp_Test;Integrated Security=true"
     }
 }


### PR DESCRIPTION
* Add AppLayerAssemblies in bootstrap options for better registration
  testing, it is quite complicated with batch processing
* Add DataLayerAssemblies in bootstrap options for better registration
  testing
* Fix validation registration, was not registering custom validators
  after data annotations. Data annotations should fire first
* Fix: register batch macros in app layer
* Fix: move efcore query tracker to an earlier registration so all
  queries are untracked
* Refactor: change testing db instance to "local", that is more explicit
* Add SingleQueryHandlerDelegator as the first delegator in line so that 
  it fires before all decorators
* Change `WriteConnectionString` in `BootstrapOptions` to `DbConnectionsString`,
  I want to get rid of read/write separation at db level for now. There is lots of 
  unnecessary overhead