### PR TITLE
feat(uow): Add `IDomainEvent` in unit of work

### DIFF
--- a/CSharp/src/BusinessApp.Domain.UnitTest/EventUnitOfWorkTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EventUnitOfWorkTests.cs
@@ -99,6 +99,26 @@ namespace BusinessApp.Domain.UnitTest
             }
 
             [Fact]
+            public async Task WithNewIDomainEvent_EventsPublishOnCommit()
+            {
+                /* Arrange */
+                var @event = A.Fake<IDomainEvent>();
+                sut.Add(@event);
+                A.CallTo(() => publisher.PublishAsync(A<IEventEmitter>._, token))
+                    .Invokes(ctx =>
+                    {
+                        ctx.GetArgument<IEventEmitter>(0).PublishEvents().ToList();
+                    });
+
+                /* Act */
+                await sut.CommitAsync(token);
+
+                /* Assert */
+                A.CallTo(() => publisher.PublishAsync(A<IEventEmitter>._, token))
+                    .MustHaveHappenedOnceExactly();
+            }
+
+            [Fact]
             public async Task WithAggregate_EventsPublishWhileExists()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.Domain/EventUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Domain/EventUnitOfWork.cs
@@ -27,6 +27,11 @@
             emitters.Add(aggregate);
         }
 
+        public void Add(IDomainEvent @event)
+        {
+            emitters.Add(new EventEmitter(@event));
+        }
+
         public virtual void Track(AggregateRoot aggregate)
         {
             emitters.Add(aggregate);
@@ -58,6 +63,29 @@
         {
             emitters.Clear();
             return Task.CompletedTask;
+        }
+
+        private sealed class EventEmitter : IEventEmitter
+        {
+            private IDomainEvent e;
+
+            public EventEmitter(IDomainEvent e)
+            {
+                this.e = e;
+            }
+
+            public bool HasEvents() => e != null;
+
+            public IEnumerable<IDomainEvent> PublishEvents()
+            {
+                if (e != null)
+                {
+                    var emitted = e;
+                    e = null;
+
+                    yield return emitted;
+                }
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain/IUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Domain/IUnitOfWork.cs
@@ -12,6 +12,7 @@
         event EventHandler Committing;
         event EventHandler Committed;
         void Add(AggregateRoot aggregate);
+        void Add(IDomainEvent @event);
         void Remove(AggregateRoot aggregate);
         void Track(AggregateRoot aggregate);
         Task CommitAsync(CancellationToken cancellationToken);

--- a/CSharp/src/BusinessApp.WebApi/DataLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/DataLayerBootstrapper.cs
@@ -71,7 +71,6 @@
                 ctx => !ctx.Handled);
             container.Register<IEventRepository, EventRepository>();
             container.Register<EFUnitOfWork>();
-            container.Register<IUnitOfWork>(() => container.GetInstance<EFUnitOfWork>());
             container.Register<ITransactionFactory>(() => container.GetInstance<EFUnitOfWork>());
 
             RegisterDbContext<BusinessAppDbContext>(container, options.DbConnectionString);

--- a/CSharp/src/BusinessApp.WebApi/DomainLayerBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/DomainLayerBootstrapper.cs
@@ -23,7 +23,7 @@
             }.Concat(options.AppAssemblies).Concat(options.DataAssemblies));
 
             container.Collection.Append(typeof(IEventHandler<>), typeof(DomainEventHandler<>));
-            container.Register<EventUnitOfWork>();
+            container.Register<IUnitOfWork, EventUnitOfWork>();
 
             container.Register<PostCommitRegister>();
             container.Register<IPostCommitRegister>(container.GetInstance<PostCommitRegister>);


### PR DESCRIPTION
DomainEvents and AggregateRoots are the two entities that should be
saved directly