### PR TITLE
refactor(bootstrap): Reorganization layered bootstraps

### DIFF
--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/BootstrapTests.App.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/BootstrapTests.App.cs
@@ -18,12 +18,12 @@ namespace BusinessApp.WebApi.IntegrationTest
     using Microsoft.Extensions.Configuration;
     using BusinessApp.Data;
 
-    public class AppLayerBootstrapperTests
+    public partial class BootstrapTests
     {
         public void CreateRegistrations(Container container)
         {
             container.RegisterInstance(A.Fake<IHttpContextAccessor>());
-            WebApiBootstrapper.Bootstrap(
+            Bootstrap.WebApi(
                 A.Dummy<IApplicationBuilder>(),
                 A.Dummy<IWebHostEnvironment>(),
                 container,
@@ -32,23 +32,23 @@ namespace BusinessApp.WebApi.IntegrationTest
                     DbConnectionString = "Server=(localdb)\\MSSQLLocalDb;Initial Catalog=foobar",
                     AppAssemblies = new[]
                     {
-                        typeof(AppLayerBootstrapperTests).Assembly,
+                        typeof(BootstrapTests).Assembly,
                         typeof(IQuery).Assembly
                     },
                     DataAssemblies = new[]
                     {
-                        typeof(AppLayerBootstrapperTests).Assembly,
+                        typeof(BootstrapTests).Assembly,
                         typeof(IQueryVisitor<>).Assembly
                     }
                 });
         }
 
-        public class Bootstrap : AppLayerBootstrapperTests, IDisposable
+        public class App : BootstrapTests, IDisposable
         {
             private readonly Container container;
             private readonly Scope scope;
 
-            public Bootstrap()
+            public App()
             {
                 container = new Container();
                 new Startup(A.Dummy<IConfiguration>(), container);
@@ -179,7 +179,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                         typeof(ValidationRequestDecorator<CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
-                        typeof(AppLayerBootstrapper.BatchScopeWrappingHandler<CommandHandlerStub, CommandStub, CommandStub>),
+                        typeof(Bootstrap.BatchScopeWrappingHandler<CommandHandlerStub, CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
                         typeof(CommandHandlerStub),
@@ -238,7 +238,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                         typeof(ValidationRequestDecorator<AuthCommandStub, AuthCommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
-                        typeof(AppLayerBootstrapper.BatchScopeWrappingHandler<AuthCommandHandlerStub, AuthCommandStub, AuthCommandStub>),
+                        typeof(Bootstrap.BatchScopeWrappingHandler<AuthCommandHandlerStub, AuthCommandStub, AuthCommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
                         typeof(AuthCommandHandlerStub),
@@ -296,7 +296,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                         typeof(TransactionRequestDecorator<IEnumerable<CommandStub>, IEnumerable<CommandStub>>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
-                        typeof(AppLayerBootstrapper.MacroScopeWrappingHandler<CommandStub, CommandStub>),
+                        typeof(Bootstrap.MacroScopeWrappingHandler<CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
                         typeof(BatchRequestDelegator<CommandStub, CommandStub>),
@@ -305,7 +305,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                         typeof(ValidationRequestDecorator<CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
-                        typeof(AppLayerBootstrapper.BatchScopeWrappingHandler<CommandHandlerStub, CommandStub, CommandStub>),
+                        typeof(Bootstrap.BatchScopeWrappingHandler<CommandHandlerStub, CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
                         typeof(CommandHandlerStub),
@@ -366,7 +366,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                         typeof(TransactionRequestDecorator<IEnumerable<CommandStub>, IEnumerable<CommandStub>>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
-                        typeof(AppLayerBootstrapper.MacroScopeWrappingHandler<CommandStub, CommandStub>),
+                        typeof(Bootstrap.MacroScopeWrappingHandler<CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
                         typeof(BatchRequestDelegator<CommandStub, CommandStub>),
@@ -375,7 +375,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                         typeof(ValidationRequestDecorator<CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
-                        typeof(AppLayerBootstrapper.BatchScopeWrappingHandler<CommandHandlerStub, CommandStub, CommandStub>),
+                        typeof(Bootstrap.BatchScopeWrappingHandler<CommandHandlerStub, CommandStub, CommandStub>),
                         rel.Registration.ImplementationType),
                     rel => Assert.Equal(
                         typeof(CommandHandlerStub),

--- a/CSharp/src/BusinessApp.WebApi/Bootstrap.App.cs
+++ b/CSharp/src/BusinessApp.WebApi/Bootstrap.App.cs
@@ -17,9 +17,9 @@
     /// <summary>
     /// Allows registering all types that are defined in the app layer
     /// </summary>
-    public static class AppLayerBootstrapper
+    public static partial class Bootstrap
     {
-        public static void Bootstrap(Container container,
+        public static void App(Container container,
             IWebHostEnvironment env,
             BootstrapOptions options)
         {

--- a/CSharp/src/BusinessApp.WebApi/Bootstrap.Data.cs
+++ b/CSharp/src/BusinessApp.WebApi/Bootstrap.Data.cs
@@ -16,7 +16,7 @@
     /// <summary>
     /// Allows registering all types that are defined in the data layer
     /// </summary>
-    public static class DataLayerBootstrapper
+    public static partial class Bootstrap
     {
 #if efcore
 //#if DEBUG
@@ -33,7 +33,7 @@
 //#endif
 #endif
 
-        public static void Bootstrap(Container container, BootstrapOptions options)
+        public static void Data(Container container, BootstrapOptions options)
         {
             container.NotNull().Expect(nameof(container));
 

--- a/CSharp/src/BusinessApp.WebApi/Bootstrap.Domain.cs
+++ b/CSharp/src/BusinessApp.WebApi/Bootstrap.Domain.cs
@@ -8,18 +8,18 @@
     /// <summary>
     /// Allows registering all types that are defined in the domain layer
     /// </summary>
-    public static class DomainLayerBoostrapper
+    public static partial class Bootstrap
     {
-        private static readonly Assembly Assembly = typeof(IEventHandler<>).Assembly;
+        private static readonly Assembly DomainAssembly = typeof(IEventHandler<>).Assembly;
 
-        public static void Bootstrap(Container container, BootstrapOptions options)
+        public static void Domain(Container container, BootstrapOptions options)
         {
             container.NotNull().Expect(nameof(container));
 
             container.Collection.Register(typeof(IEventHandler<>), new[]
             {
-                Assembly,
-                WebApiBootstrapper.Assembly
+                DomainAssembly,
+                StartupAssembly
             }.Concat(options.AppAssemblies).Concat(options.DataAssemblies));
 
             container.Collection.Append(typeof(IEventHandler<>), typeof(DomainEventHandler<>));

--- a/CSharp/src/BusinessApp.WebApi/Bootstrap.WebApi.cs
+++ b/CSharp/src/BusinessApp.WebApi/Bootstrap.WebApi.cs
@@ -16,18 +16,18 @@
     /// <summary>
     /// Allows registering all types that are defined in the web api layer
     /// </summary>
-    public static class WebApiBootstrapper
+    public static partial class Bootstrap
     {
-        public static readonly Assembly Assembly = typeof(Startup).Assembly;
+        public static readonly Assembly StartupAssembly = typeof(Startup).Assembly;
 
-        public static Container Bootstrap(IApplicationBuilder app,
+        public static Container WebApi(IApplicationBuilder app,
             IWebHostEnvironment env,
             Container container,
             BootstrapOptions options)
         {
-            DomainLayerBoostrapper.Bootstrap(container, options);
-            DataLayerBootstrapper.Bootstrap(container, options);
-            AppLayerBootstrapper.Bootstrap(container, env, options);
+            Bootstrap.Domain(container, options);
+            Bootstrap.Data(container, options);
+            Bootstrap.App(container, env, options);
 
 #if json
             Json.Bootstrapper.Bootstrap(container);
@@ -45,7 +45,7 @@
             container.RegisterDecorator<IProblemDetailFactory, ProblemDetailFactoryHttpDecorator>(
                 Lifestyle.Singleton);
 
-            container.Register(typeof(IHttpRequestHandler<,>), Assembly);
+            container.Register(typeof(IHttpRequestHandler<,>), StartupAssembly);
             container.RegisterConditional(
                 typeof(IHttpRequestHandler<,>),
                 typeof(EnvelopeQueryResourceHandler<,>),

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -99,7 +99,7 @@
 #endif
             app.SetupEndpoints(container);
 
-            WebApiBootstrapper.Bootstrap(app, env, container, options);
+            Bootstrap.WebApi(app, env, container, options);
             container.Verify();
 
             if (env.EnvironmentName.Equals("Development", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Move all bootstrap methods to partial `Bootstrap` class. Begin to
reorganize bootstrap methods so all compiler directives can be
consolidated and testing easier

related #4819