### PR TITLE
feat(uow): Add method to find an aggregate root

### DIFF
--- a/CSharp/src/BusinessApp.Data.IntegrationTest/EFUnitOfWorkTests.cs
+++ b/CSharp/src/BusinessApp.Data.IntegrationTest/EFUnitOfWorkTests.cs
@@ -420,5 +420,40 @@ namespace BusinessApp.Data.IntegrationTest
                 Assert.NotNull(addedEntity);
             }
         }
+
+        public class Find : EFUnitOfWorkTests
+        {
+            public Find(DatabaseFixture fixture)
+                :base(fixture)
+            {}
+
+            [Fact]
+            public void ReturnsAllTypedAggregateRoots()
+            {
+                /* Arrange */
+                var ar1 = new ARStub();
+                var ar2 = new ARStub();
+                var other = A.Dummy<AnotherARStub>();
+                sut.Track(ar1);
+                sut.Track(ar2);
+                sut.Track(other);
+
+                /* Act */
+                var instance = sut.Find<ARStub>(a => a.Equals(ar1));
+
+                /* Assert */
+                Assert.Same(ar1, instance);
+            }
+
+            private sealed class ARStub : AggregateRoot
+            {
+                public int Id { get; set; }
+            }
+
+            private sealed class AnotherARStub : AggregateRoot
+            {
+                public int Id { get; set; }
+            }
+        }
     }
 }

--- a/CSharp/src/BusinessApp.Data.IntegrationTest/EFUnitOfWorkTests.cs
+++ b/CSharp/src/BusinessApp.Data.IntegrationTest/EFUnitOfWorkTests.cs
@@ -432,17 +432,14 @@ namespace BusinessApp.Data.IntegrationTest
             {
                 /* Arrange */
                 var ar1 = new ARStub();
-                var ar2 = new ARStub();
-                var other = A.Dummy<AnotherARStub>();
-                sut.Track(ar1);
-                sut.Track(ar2);
-                sut.Track(other);
+                Func<ARStub, bool> filter = a => a.Equals(ar1);
+                A.CallTo(() => inner.Find<ARStub>(filter)).Returns(ar1);
 
                 /* Act */
                 var instance = sut.Find<ARStub>(a => a.Equals(ar1));
 
                 /* Assert */
-                Assert.Same(ar1, instance);
+                Assert.Same(instance, ar1);
             }
 
             private sealed class ARStub : AggregateRoot

--- a/CSharp/src/BusinessApp.Data.IntegrationTest/EFUnitOfWorkTests.cs
+++ b/CSharp/src/BusinessApp.Data.IntegrationTest/EFUnitOfWorkTests.cs
@@ -436,10 +436,10 @@ namespace BusinessApp.Data.IntegrationTest
                 A.CallTo(() => inner.Find<ARStub>(filter)).Returns(ar1);
 
                 /* Act */
-                var instance = sut.Find<ARStub>(a => a.Equals(ar1));
+                var instance = sut.Find<ARStub>(filter);
 
                 /* Assert */
-                Assert.Same(instance, ar1);
+                Assert.Same(ar1, instance);
             }
 
             private sealed class ARStub : AggregateRoot

--- a/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
@@ -24,13 +24,28 @@ namespace BusinessApp.Data
         public event EventHandler Committing = delegate {};
         public event EventHandler Committed = delegate {};
 
-        public void Track(AggregateRoot aggregate) => db.Attach(aggregate);
+        public void Track(AggregateRoot aggregate)
+        {
+            inner.Track(aggregate);
+        }
 
-        public void Add(AggregateRoot aggregate) => db.Add(aggregate);
 
-        public void Add(IDomainEvent @event) => db.Add(@event);
+        public void Add(AggregateRoot aggregate)
+        {
+            inner.Add(aggregate);
+        }
 
-        public void Remove(AggregateRoot aggregate) => db.Remove(aggregate);
+
+        public void Add(IDomainEvent @event)
+        {
+            inner.Add(@event);
+        }
+
+
+        public void Remove(AggregateRoot aggregate)
+        {
+            inner.Remove(aggregate);
+        }
 
         public async Task CommitAsync(CancellationToken cancellationToken)
         {
@@ -90,7 +105,9 @@ namespace BusinessApp.Data
 
         public TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot
         {
-            return inner.Find<TRoot>(filter);
+            return db.ChangeTracker.Entries<TRoot>()
+                .Select(e => e.Entity)
+                .SingleOrDefault(filter);
         }
     }
 }

--- a/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
@@ -24,25 +24,13 @@ namespace BusinessApp.Data
         public event EventHandler Committing = delegate {};
         public event EventHandler Committed = delegate {};
 
-        public void Track(AggregateRoot aggregate)
-        {
-            inner.Track(aggregate);
-        }
+        public void Track(AggregateRoot aggregate) => db.Attach(aggregate);
 
-        public void Add(AggregateRoot aggregate)
-        {
-            inner.Add(aggregate);
-        }
+        public void Add(AggregateRoot aggregate) => db.Add(aggregate);
 
-        public void Add(IDomainEvent @event)
-        {
-            inner.Add(@event);
-        }
+        public void Add(IDomainEvent @event) => db.Add(@event);
 
-        public void Remove(AggregateRoot aggregate)
-        {
-            inner.Remove(aggregate);
-        }
+        public void Remove(AggregateRoot aggregate) => db.Remove(aggregate);
 
         public async Task CommitAsync(CancellationToken cancellationToken)
         {
@@ -102,9 +90,7 @@ namespace BusinessApp.Data
 
         public TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot
         {
-            return db.ChangeTracker.Entries<TRoot>()
-                .Select(e => e.Entity)
-                .SingleOrDefault(filter);
+            return inner.Find<TRoot>(filter);
         }
     }
 }

--- a/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
@@ -29,18 +29,15 @@ namespace BusinessApp.Data
             inner.Track(aggregate);
         }
 
-
         public void Add(AggregateRoot aggregate)
         {
             inner.Add(aggregate);
         }
 
-
         public void Add(IDomainEvent @event)
         {
             inner.Add(@event);
         }
-
 
         public void Remove(AggregateRoot aggregate)
         {
@@ -105,9 +102,7 @@ namespace BusinessApp.Data
 
         public TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot
         {
-            return db.ChangeTracker.Entries<TRoot>()
-                .Select(e => e.Entity)
-                .SingleOrDefault(filter);
+            return inner.Find<TRoot>(filter);
         }
     }
 }

--- a/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
@@ -2,6 +2,7 @@ namespace BusinessApp.Data
 {
     using System;
     using System.Data;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using BusinessApp.App;
@@ -97,6 +98,13 @@ namespace BusinessApp.Data
             transactionFromFactory = true;
 
             return this;
+        }
+
+        public TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot
+        {
+            return db.ChangeTracker.Entries<TRoot>()
+                .Select(e => e.Entity)
+                .SingleOrDefault(filter);
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain.UnitTest/EventUnitOfWorkTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EventUnitOfWorkTests.cs
@@ -214,5 +214,26 @@ namespace BusinessApp.Domain.UnitTest
                     .MustNotHaveHappened();
             }
         }
+
+        public class FindAll : EventUnitOfWorkTests
+        {
+            [Fact]
+            public void ReturnsAllTypedAggregateRoots()
+            {
+                /* Arrange */
+                var ar1 = new AggregateRootFake();
+                var ar2 = new AggregateRootFake();
+                var other = A.Dummy<AggregateRoot>();
+                sut.Track(ar1);
+                sut.Track(ar2);
+                sut.Track(other);
+
+                /* Act */
+                var instance = sut.Find<AggregateRootFake>(a => a.Equals(ar1));
+
+                /* Assert */
+                Assert.Same(instance, ar1);
+            }
+        }
     }
 }

--- a/CSharp/src/BusinessApp.Domain/EventUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Domain/EventUnitOfWork.cs
@@ -65,6 +65,14 @@
             return Task.CompletedTask;
         }
 
+        public TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot
+        {
+            return emitters
+                .Where(e => e.GetType() == typeof(TRoot))
+                .Cast<TRoot>()
+                .SingleOrDefault(filter);
+        }
+
         private sealed class EventEmitter : IEventEmitter
         {
             private IDomainEvent e;

--- a/CSharp/src/BusinessApp.Domain/IUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Domain/IUnitOfWork.cs
@@ -11,6 +11,7 @@
     {
         event EventHandler Committing;
         event EventHandler Committed;
+        TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot;
         void Add(AggregateRoot aggregate);
         void Add(IDomainEvent @event);
         void Remove(AggregateRoot aggregate);


### PR DESCRIPTION
Useful in event handling you an event emits with an aggregate root id.
You should safely assume it is already in the unit of work so you do not
have to go looking in the repository. Looking in the repository is a bit
awkward because you do not know if it is hitting a database or the
repository has an identity map implementation

fixes [AB#5628](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/5628)