### PR TITLE
fix(metadata): Change EF Entity configuration for metadata data

### DIFF
--- a/CSharp/src/BusinessApp.App/NoBusinessLogicRequestHandler.cs
+++ b/CSharp/src/BusinessApp.App/NoBusinessLogicRequestHandler.cs
@@ -1,0 +1,25 @@
+namespace BusinessApp.App
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using BusinessApp.Domain;
+
+    /// <summary>
+    /// Null request handler for requests that have no business logic
+    /// </summary>
+    /// <remarks>
+    /// Set this handler up to target command requests that have no business logic
+    /// and simple save the incoming request. Most of the needed logic is already
+    /// baked into the decorators
+    /// </remarks>
+    public class NoBusinessLogicRequestHandler<TRequest> :
+        IRequestHandler<TRequest, TRequest>
+    {
+        public Task<Result<TRequest, Exception>> HandleAsync(TRequest request,
+            CancellationToken cancelToken)
+        {
+            return Task.FromResult(Result.Ok(request));
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Data/MetadataEntityConfiguration.cs
+++ b/CSharp/src/BusinessApp.Data/MetadataEntityConfiguration.cs
@@ -35,15 +35,18 @@ namespace BusinessApp.Data
         }
     }
 
-    public abstract class MetadataEntityConfiguration<T> :
-        IEntityTypeConfiguration<Metadata<T>>
+    public abstract class MetadataEntityConfiguration<T> : IEntityTypeConfiguration<T>
         where T : class
     {
         protected abstract string TableName { get; }
 
-        public virtual void Configure(EntityTypeBuilder<Metadata<T>> builder)
+        public virtual void Configure(EntityTypeBuilder<T> builder)
         {
             builder.ToTable(TableName, "dbo");
+
+            builder.HasOne<Metadata<T>>()
+                .WithOne(e => e.Data)
+                .HasForeignKey<T>("MetadataId");
         }
     }
 }

--- a/CSharp/src/BusinessApp.Test.Shared/BusinessAppTestDbContext.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/BusinessAppTestDbContext.cs
@@ -87,7 +87,14 @@ namespace BusinessApp.Test.Shared
 
             base.OnModelCreating(modelBuilder);
 
+#region Event Streaming
             modelBuilder.ApplyConfiguration(new DeleteEventConfiguration());
+#endregion
+
+#region Command Streaming
+            modelBuilder.ApplyConfiguration(new DeleteQueryConfiguration());
+            modelBuilder.ApplyConfiguration(new PostOrPutBodyConfiguration());
+#endregion
         }
 
         private class DeleteEventConfiguration : EventMetadataEntityConfiguration<Delete.Event>
@@ -98,6 +105,46 @@ namespace BusinessApp.Test.Shared
                 OwnedNavigationBuilder<EventMetadata<Delete.Event>, Delete.Event> builder)
             {
                 builder.Property(p => p.Id)
+                    .HasConversion(id => (int)id, val => new EntityId(val));
+            }
+        }
+
+        private class PostOrPutBodyConfiguration : MetadataEntityConfiguration<PostOrPut.Body>
+        {
+            protected override string TableName => "PostOrPutBody";
+
+            public override void Configure(EntityTypeBuilder<PostOrPut.Body> builder)
+            {
+                base.Configure(builder);
+
+                builder.ToTable("PostOrPutBody");
+
+                builder.Property<int>("PostOrPutBodyRequestId")
+                    .ValueGeneratedOnAdd();
+
+                builder.HasKey("PostOrPutBodyRequestId");
+
+                builder.Property(p => p.Id)
+                    .HasColumnName("PostOrPutId")
+                    .HasConversion(id => (int)id, val => new EntityId(val));
+            }
+        }
+
+        private class DeleteQueryConfiguration : MetadataEntityConfiguration<Delete.Query>
+        {
+            protected override string TableName => "DeleteQuery";
+
+            public override void Configure(EntityTypeBuilder<Delete.Query> builder)
+            {
+                base.Configure(builder);
+
+                builder.Property<int>("DeleteQueryRequestId")
+                    .ValueGeneratedOnAdd();
+
+                builder.HasKey("DeleteQueryRequestId");
+
+                builder.Property(p => p.Id)
+                    .HasColumnName("DeleteQueryId")
                     .HasConversion(id => (int)id, val => new EntityId(val));
             }
         }

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.Designer.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BusinessApp.Test.Shared.Migrations
 {
     [DbContext(typeof(BusinessAppTestDbContext))]
-    [Migration("20210318120051_CreateTestDb")]
+    [Migration("20210318173620_CreateTestDb")]
     partial class CreateTestDb
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -61,6 +61,10 @@ namespace BusinessApp.Test.Shared.Migrations
                         .HasColumnType("varchar(100)")
                         .HasColumnName("DataSetName");
 
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<DateTimeOffset>("OccurredUtc")
                         .HasColumnType("datetimeoffset(0)")
                         .HasColumnName("OccurredUtc");
@@ -78,6 +82,8 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Metadata", "dbo");
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("Metadata");
                 });
 
             modelBuilder.Entity("BusinessApp.Test.Shared.AggregateRootStub", b =>
@@ -151,6 +157,69 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.ToTable("ResponseStub");
                 });
 
+            modelBuilder.Entity("BusinessApp.WebApi.Delete+Query", b =>
+                {
+                    b.Property<int>("DeleteQueryRequestId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<int?>("Id")
+                        .HasColumnType("int")
+                        .HasColumnName("DeleteQueryId");
+
+                    b.Property<long?>("MetadataId")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("DeleteQueryRequestId");
+
+                    b.HasIndex("MetadataId")
+                        .IsUnique()
+                        .HasFilter("[MetadataId] IS NOT NULL");
+
+                    b.ToTable("DeleteQuery", "dbo");
+                });
+
+            modelBuilder.Entity("BusinessApp.WebApi.PostOrPut+Body", b =>
+                {
+                    b.Property<int>("PostOrPutBodyRequestId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<int?>("Id")
+                        .HasColumnType("int")
+                        .HasColumnName("PostOrPutId");
+
+                    b.Property<long>("LongerId")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("MetadataId")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("PostOrPutBodyRequestId");
+
+                    b.HasIndex("MetadataId")
+                        .IsUnique()
+                        .HasFilter("[MetadataId] IS NOT NULL");
+
+                    b.ToTable("PostOrPutBody");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.Delete+Query>", b =>
+                {
+                    b.HasBaseType("BusinessApp.Data.Metadata");
+
+                    b.HasDiscriminator().HasValue("Metadata<Query>");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.PostOrPut+Body>", b =>
+                {
+                    b.HasBaseType("BusinessApp.Data.Metadata");
+
+                    b.HasDiscriminator().HasValue("Metadata<Body>");
+                });
+
             modelBuilder.Entity("BusinessApp.Data.EventMetadata<BusinessApp.WebApi.Delete+Event>", b =>
                 {
                     b.HasOne("BusinessApp.Data.Metadata", null)
@@ -196,9 +265,33 @@ namespace BusinessApp.Test.Shared.Migrations
                         .HasForeignKey("ResponseStubId");
                 });
 
+            modelBuilder.Entity("BusinessApp.WebApi.Delete+Query", b =>
+                {
+                    b.HasOne("BusinessApp.Data.Metadata<BusinessApp.WebApi.Delete+Query>", null)
+                        .WithOne("Data")
+                        .HasForeignKey("BusinessApp.WebApi.Delete+Query", "MetadataId");
+                });
+
+            modelBuilder.Entity("BusinessApp.WebApi.PostOrPut+Body", b =>
+                {
+                    b.HasOne("BusinessApp.Data.Metadata<BusinessApp.WebApi.PostOrPut+Body>", null)
+                        .WithOne("Data")
+                        .HasForeignKey("BusinessApp.WebApi.PostOrPut+Body", "MetadataId");
+                });
+
             modelBuilder.Entity("BusinessApp.Test.Shared.ResponseStub", b =>
                 {
                     b.Navigation("ChildResponseStubs");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.Delete+Query>", b =>
+                {
+                    b.Navigation("Data");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.PostOrPut+Body>", b =>
+                {
+                    b.Navigation("Data");
                 });
 #pragma warning restore 612, 618
         }

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.cs
@@ -46,7 +46,8 @@ namespace BusinessApp.Test.Shared.Migrations
                     Username = table.Column<string>(type: "varchar(100)", nullable: false),
                     DataSetName = table.Column<string>(type: "varchar(100)", nullable: false),
                     TypeName = table.Column<string>(type: "varchar(100)", nullable: false),
-                    OccurredUtc = table.Column<DateTimeOffset>(type: "datetimeoffset(0)", nullable: false)
+                    OccurredUtc = table.Column<DateTimeOffset>(type: "datetimeoffset(0)", nullable: false),
+                    Discriminator = table.Column<string>(type: "nvarchar(max)", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -109,6 +110,50 @@ namespace BusinessApp.Test.Shared.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "DeleteQuery",
+                schema: "dbo",
+                columns: table => new
+                {
+                    DeleteQueryRequestId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    DeleteQueryId = table.Column<int>(type: "int", nullable: true),
+                    MetadataId = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeleteQuery", x => x.DeleteQueryRequestId);
+                    table.ForeignKey(
+                        name: "FK_DeleteQuery_Metadata_MetadataId",
+                        column: x => x.MetadataId,
+                        principalSchema: "dbo",
+                        principalTable: "Metadata",
+                        principalColumn: "MetadataId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PostOrPutBody",
+                columns: table => new
+                {
+                    PostOrPutBodyRequestId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    LongerId = table.Column<long>(type: "bigint", nullable: false),
+                    PostOrPutId = table.Column<int>(type: "int", nullable: true),
+                    MetadataId = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PostOrPutBody", x => x.PostOrPutBodyRequestId);
+                    table.ForeignKey(
+                        name: "FK_PostOrPutBody_Metadata_MetadataId",
+                        column: x => x.MetadataId,
+                        principalSchema: "dbo",
+                        principalTable: "Metadata",
+                        principalColumn: "MetadataId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "ChildResponseStub",
                 columns: table => new
                 {
@@ -140,6 +185,21 @@ namespace BusinessApp.Test.Shared.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_DeleteQuery_MetadataId",
+                schema: "dbo",
+                table: "DeleteQuery",
+                column: "MetadataId",
+                unique: true,
+                filter: "[MetadataId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PostOrPutBody_MetadataId",
+                table: "PostOrPutBody",
+                column: "MetadataId",
+                unique: true,
+                filter: "[MetadataId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_ResponseStub_ResponseStubId",
                 table: "ResponseStub",
                 column: "ResponseStubId");
@@ -158,7 +218,14 @@ namespace BusinessApp.Test.Shared.Migrations
                 schema: "evt");
 
             migrationBuilder.DropTable(
+                name: "DeleteQuery",
+                schema: "dbo");
+
+            migrationBuilder.DropTable(
                 name: "DomainEventStub");
+
+            migrationBuilder.DropTable(
+                name: "PostOrPutBody");
 
             migrationBuilder.DropTable(
                 name: "RequestStub");

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/BusinessAppTestDbContextModelSnapshot.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/BusinessAppTestDbContextModelSnapshot.cs
@@ -59,6 +59,10 @@ namespace BusinessApp.Test.Shared.Migrations
                         .HasColumnType("varchar(100)")
                         .HasColumnName("DataSetName");
 
+                    b.Property<string>("Discriminator")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<DateTimeOffset>("OccurredUtc")
                         .HasColumnType("datetimeoffset(0)")
                         .HasColumnName("OccurredUtc");
@@ -76,6 +80,8 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Metadata", "dbo");
+
+                    b.HasDiscriminator<string>("Discriminator").HasValue("Metadata");
                 });
 
             modelBuilder.Entity("BusinessApp.Test.Shared.AggregateRootStub", b =>
@@ -149,6 +155,69 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.ToTable("ResponseStub");
                 });
 
+            modelBuilder.Entity("BusinessApp.WebApi.Delete+Query", b =>
+                {
+                    b.Property<int>("DeleteQueryRequestId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<int?>("Id")
+                        .HasColumnType("int")
+                        .HasColumnName("DeleteQueryId");
+
+                    b.Property<long?>("MetadataId")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("DeleteQueryRequestId");
+
+                    b.HasIndex("MetadataId")
+                        .IsUnique()
+                        .HasFilter("[MetadataId] IS NOT NULL");
+
+                    b.ToTable("DeleteQuery", "dbo");
+                });
+
+            modelBuilder.Entity("BusinessApp.WebApi.PostOrPut+Body", b =>
+                {
+                    b.Property<int>("PostOrPutBodyRequestId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                    b.Property<int?>("Id")
+                        .HasColumnType("int")
+                        .HasColumnName("PostOrPutId");
+
+                    b.Property<long>("LongerId")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("MetadataId")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("PostOrPutBodyRequestId");
+
+                    b.HasIndex("MetadataId")
+                        .IsUnique()
+                        .HasFilter("[MetadataId] IS NOT NULL");
+
+                    b.ToTable("PostOrPutBody");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.Delete+Query>", b =>
+                {
+                    b.HasBaseType("BusinessApp.Data.Metadata");
+
+                    b.HasDiscriminator().HasValue("Metadata<Query>");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.PostOrPut+Body>", b =>
+                {
+                    b.HasBaseType("BusinessApp.Data.Metadata");
+
+                    b.HasDiscriminator().HasValue("Metadata<Body>");
+                });
+
             modelBuilder.Entity("BusinessApp.Data.EventMetadata<BusinessApp.WebApi.Delete+Event>", b =>
                 {
                     b.HasOne("BusinessApp.Data.Metadata", null)
@@ -194,9 +263,33 @@ namespace BusinessApp.Test.Shared.Migrations
                         .HasForeignKey("ResponseStubId");
                 });
 
+            modelBuilder.Entity("BusinessApp.WebApi.Delete+Query", b =>
+                {
+                    b.HasOne("BusinessApp.Data.Metadata<BusinessApp.WebApi.Delete+Query>", null)
+                        .WithOne("Data")
+                        .HasForeignKey("BusinessApp.WebApi.Delete+Query", "MetadataId");
+                });
+
+            modelBuilder.Entity("BusinessApp.WebApi.PostOrPut+Body", b =>
+                {
+                    b.HasOne("BusinessApp.Data.Metadata<BusinessApp.WebApi.PostOrPut+Body>", null)
+                        .WithOne("Data")
+                        .HasForeignKey("BusinessApp.WebApi.PostOrPut+Body", "MetadataId");
+                });
+
             modelBuilder.Entity("BusinessApp.Test.Shared.ResponseStub", b =>
                 {
                     b.Navigation("ChildResponseStubs");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.Delete+Query>", b =>
+                {
+                    b.Navigation("Data");
+                });
+
+            modelBuilder.Entity("BusinessApp.Data.Metadata<BusinessApp.WebApi.PostOrPut+Body>", b =>
+                {
+                    b.Navigation("Data");
                 });
 #pragma warning restore 612, 618
         }

--- a/CSharp/src/BusinessApp.WebApi/RoutingBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/RoutingBootstrapper.cs
@@ -175,14 +175,6 @@
             public long LongerId { get; set; }
             public EntityId Id { get; set; }
         }
-
-        public class Handler : App.IRequestHandler<Body, Body>
-        {
-            public Task<Result<Body, Exception>> HandleAsync(Body request, CancellationToken cancelToken)
-            {
-                return Task.FromResult(Result.Ok(request));
-            }
-        }
     }
 
     public class Delete

--- a/CSharp/src/BusinessApp.WebApi/ServiceRegistrations/MainRegister.cs
+++ b/CSharp/src/BusinessApp.WebApi/ServiceRegistrations/MainRegister.cs
@@ -265,6 +265,11 @@ namespace BusinessApp.WebApi
                         !c.ServiceType.GetGenericArguments()[1].IsGenericType
                         || c.ServiceType.GetGenericArguments()[1].GetGenericTypeDefinition() != typeof(IEnumerable<>)
                     ));
+
+            container.RegisterConditional(typeof(IRequestHandler<,>),
+                typeof(NoBusinessLogicRequestHandler<>),
+                Lifestyle.Scoped,
+                c => !c.Handled);
         }
 
         private void RegisterDecoratePipeline(RegistrationContext context)


### PR DESCRIPTION
* refactor: Configure the `Data` property in the DbSet for the relationship
  to save with the `Metadata<T>` by changing the abstract
  `IEntityConfiguration` to target the metadata.Data type.
* feat: Add a null request handler for commands since the decorators could
  do all the heavy work of saving the metadata+data. This is nice for CRUD
  type situations

fixes [AB#5849](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/5849)