### PR TITLE
feat(webapi): Return an http HandlerContext

### DIFF
--- a/CSharp/src/BusinessApp.WebApi.UnitTest/HttpRequestLoggingDecoratorTest.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/HttpRequestLoggingDecoratorTest.cs
@@ -161,7 +161,7 @@ namespace BusinessApp.WebApi.UnitTest
             {
                 /* Arrange */
                 var expectedMsg = "Your request could not be read because some " +
-                    "arguments may be in the wrong format. Please review your requets " +
+                    "arguments may be in the wrong format. Please review your request " +
                     "and try again";
                 var formatError = new FormatException();
                 var exception = new ArgumentException("foo", formatError);

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/HttpResponseDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/HttpResponseDecoratorTests.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.WebApi.UnitTest
     using System.Collections.Generic;
     using System.Threading;
 
-    using Result = Domain.Result<ResponseStub, System.Exception>;
+    using HandlerResult = Domain.Result<HandlerContext<RequestStub, ResponseStub>, System.Exception>;
 
     public class HttpResponseDecoratorTests
     {
@@ -84,7 +84,8 @@ namespace BusinessApp.WebApi.UnitTest
             public async Task ResponseStarted_ExceptionThrown()
             {
                 /* Arrange */
-                A.CallTo(() => inner.HandleAsync(context, cancelToken)).Returns(A.Dummy<Result>());
+                A.CallTo(() => inner.HandleAsync(context, cancelToken))
+                    .Returns(A.Dummy<HandlerResult>());
                 A.CallTo(() => context.Response.HasStarted).Returns(true);
 
                 /* Act */
@@ -105,7 +106,7 @@ namespace BusinessApp.WebApi.UnitTest
                 /* Arrange */
                 var blob = new byte[0];
                 var model = A.Dummy<ResponseStub>();
-                var result = Result.Ok(model);
+                var result = HandlerResult.Ok(HandlerContext.Create(A.Dummy<RequestStub>(), model));
                 A.CallTo(() => inner.HandleAsync(context, cancelToken)).Returns(result);
                 A.CallTo(() => serializer.Serialize(model)).Returns(blob);
 
@@ -123,7 +124,7 @@ namespace BusinessApp.WebApi.UnitTest
                 /* Arrange */
                 var error = A.Dummy<Exception>();
                 ProblemDetail problem = new TestProblemDetail();
-                var result = Result.Error(error);
+                var result = HandlerResult.Error(error);
                 A.CallTo(() => problemFactory.Create(error)).Returns(problem);
                 A.CallTo(() => inner.HandleAsync(context, cancelToken)).Returns(result);
 
@@ -140,7 +141,7 @@ namespace BusinessApp.WebApi.UnitTest
                 /* Arrange */
                 var error = A.Dummy<Exception>();
                 ProblemDetail problem = new TestProblemDetail(400);
-                var result = Result.Error(error);
+                var result = HandlerResult.Error(error);
                 A.CallTo(() => problemFactory.Create(error)).Returns(problem);
                 A.CallTo(() => inner.HandleAsync(context, cancelToken)).Returns(result);
 
@@ -164,10 +165,10 @@ namespace BusinessApp.WebApi.UnitTest
                 int currentStatus, string method, int statusSetCalls)
             {
                 /* Arrange */
+                var model = A.Dummy<ResponseStub>();
+                var result = HandlerResult.Ok(HandlerContext.Create(A.Dummy<RequestStub>(), model));
                 A.CallTo(() => context.Response.StatusCode).Returns(currentStatus);
                 A.CallTo(() => context.Request.Method).Returns(method);
-                var model = A.Dummy<ResponseStub>();
-                var result = Result.Ok(model);
                 A.CallTo(() => inner.HandleAsync(context, cancelToken)).Returns(result);
 
                 /* Act */
@@ -184,9 +185,8 @@ namespace BusinessApp.WebApi.UnitTest
                 /* Arrange */
                 A.CallTo(() => context.Response.StatusCode).Returns(200);
                 A.CallTo(() => context.Request.Method).Returns("put");
-                var model = A.Dummy<ResponseStub>();
-                var result = Result.Ok(model);
-                A.CallTo(() => inner.HandleAsync(context, cancelToken)).Returns(result);
+                A.CallTo(() => inner.HandleAsync(context, cancelToken))
+                    .Returns(A.Dummy<HandlerResult>());
 
                 /* Act */
                 await sut.HandleAsync(context, cancelToken);

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/Json/JsonHttpDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/Json/JsonHttpDecoratorTests.cs
@@ -10,6 +10,9 @@ namespace BusinessApp.WebApi.UnitTest.Json
     using Microsoft.AspNetCore.Http;
     using Xunit;
 
+    using Result = Domain.Result<HandlerContext<RequestStub, ResponseStub>, System.Exception>;
+    using HandlerResponse = HandlerContext<RequestStub, ResponseStub>;
+
     public class JsonHttpDecoratorTests
     {
         private readonly IHttpRequestHandler<RequestStub, ResponseStub> inner;
@@ -93,7 +96,7 @@ namespace BusinessApp.WebApi.UnitTest.Json
             {
                 /* Arrange */
                 A.CallTo(() => inner.HandleAsync(context, cancelToken))
-                    .Returns(Result.Ok(A.Dummy<ResponseStub>()));
+                    .Returns(Result.Ok(A.Dummy<HandlerResponse>()));
 
                 /* Act */
                 var result = await sut.HandleAsync(context, cancelToken);
@@ -108,7 +111,7 @@ namespace BusinessApp.WebApi.UnitTest.Json
             {
                 /* Arrange */
                 A.CallTo(() => inner.HandleAsync(context, cancelToken))
-                    .Returns(Result.Error<ResponseStub>(A.Dummy<Exception>()));
+                    .Returns(Result.Error(A.Dummy<Exception>()));
 
                 /* Act */
                 var result = await sut.HandleAsync(context, cancelToken);

--- a/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
@@ -9,25 +9,24 @@ namespace BusinessApp.WebApi
     using BusinessApp.Domain;
     using System;
 
-    public class EnvelopeQueryResourceHandler<TRequest, TResponse> :
-        IHttpRequestHandler<TRequest, IEnumerable<TResponse>>
-        where TRequest : IQuery
+    public class EnvelopeQueryResourceHandler<T, R> : IHttpRequestHandler<T, IEnumerable<R>>
+        where T : IQuery
     {
-        private readonly IRequestHandler<TRequest, EnvelopeContract<TResponse>> handler;
+        private readonly IRequestHandler<T, EnvelopeContract<R>> handler;
         private readonly ISerializer serializer;
 
         public EnvelopeQueryResourceHandler(
-            IRequestHandler<TRequest, EnvelopeContract<TResponse>> handler,
+            IRequestHandler<T, EnvelopeContract<R>> handler,
             ISerializer serializer)
         {
             this.handler = handler.NotNull().Expect(nameof(handler));
             this.serializer = serializer.NotNull().Expect(nameof(serializer));
         }
 
-        public async Task<Result<IEnumerable<TResponse>, Exception>> HandleAsync(HttpContext context,
-            CancellationToken cancelToken)
+        public async Task<Result<HandlerContext<T, IEnumerable<R>>, Exception>> HandleAsync(
+            HttpContext context, CancellationToken cancelToken)
         {
-            var query = await context.Request.DeserializeAsync<TRequest>(serializer, cancelToken);
+            var query = await context.Request.DeserializeAsync<T>(serializer, cancelToken);
 
             if (query == null)
             {
@@ -41,7 +40,7 @@ namespace BusinessApp.WebApi
                     context.Response.Headers.Add("VND.parkeremg.pagination",
                         new StringValues(envelope.Pagination.ToHeaderValue()));
 
-                    return envelope.Data;
+                    return HandlerContext.Create(query, envelope.Data);
                 });
         }
     }

--- a/CSharp/src/BusinessApp.WebApi/HandlerContext.cs
+++ b/CSharp/src/BusinessApp.WebApi/HandlerContext.cs
@@ -1,0 +1,25 @@
+﻿namespace BusinessApp.WebApi
+{
+    using System.Diagnostics;
+
+    public class HandlerContext<T, R>
+    {
+        public HandlerContext(T request, R response)
+        {
+            Request = request;
+            Response = response;
+        }
+
+        public T Request { get; }
+        public R Response { get; }
+    }
+
+    [DebuggerStepThrough]
+    public class HandlerContext
+    {
+        public static HandlerContext<T, R> Create<T, R>(T request, R response)
+        {
+            return new HandlerContext<T, R>(request, response);
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/HttpRequestLoggingDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpRequestLoggingDecorator.cs
@@ -9,21 +9,20 @@ namespace BusinessApp.WebApi
     /// <summary>
     /// Logs certains aspects of a request
     /// </summary>
-    public class HttpRequestLoggingDecorator<TRequest, TResponse>
-        : IHttpRequestHandler<TRequest, TResponse>
+    public class HttpRequestLoggingDecorator<T, R> : IHttpRequestHandler<T, R>
     {
-        private readonly IHttpRequestHandler<TRequest, TResponse> inner;
+        private readonly IHttpRequestHandler<T, R> inner;
         private readonly ILogger logger;
 
-        public HttpRequestLoggingDecorator(IHttpRequestHandler<TRequest, TResponse> inner,
+        public HttpRequestLoggingDecorator(IHttpRequestHandler<T, R> inner,
             ILogger logger)
         {
             this.inner = inner.NotNull().Expect(nameof(inner));
             this.logger = logger.NotNull().Expect(nameof(logger));
         }
 
-        public async Task<Result<TResponse, Exception>> HandleAsync(HttpContext context,
-            CancellationToken cancelToken)
+        public async Task<Result<HandlerContext<T, R>, Exception>> HandleAsync(
+            HttpContext context, CancellationToken cancelToken)
         {
             try
             {
@@ -33,18 +32,18 @@ namespace BusinessApp.WebApi
             {
                 Log(exception);
 
-                return Result.Error<TResponse>(
+                return Result.Error<HandlerContext<T, R>>(
                     new BadStateException("Your request could not be read because some " +
-                        "arguments may be in the wrong format. Please review your requets " +
+                        "arguments may be in the wrong format. Please review your request " +
                         "and try again"));
             }
             catch (Exception exception)
             {
                 Log(exception);
 
-                return Result.Error<TResponse>(new BusinessAppWebApiException(
-                    "An unknown error occurred while processing your request. Please try " +
-                    "again or contact support if this continues"));
+                return Result.Error<HandlerContext<T, R>>(
+                    new BusinessAppWebApiException("An unknown error occurred while processing " +
+                        "your request. Please try again or contact support if this continues"));
             }
         }
 

--- a/CSharp/src/BusinessApp.WebApi/IHttpRequestHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/IHttpRequestHandler.cs
@@ -1,14 +1,19 @@
 namespace BusinessApp.WebApi
 {
+    using Microsoft.AspNetCore.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
     using BusinessApp.Domain;
     using System;
 
-    public interface IHttpRequestHandler<TRequest, TResponse>
+    /// <summary>
+    /// Interface to handle an HTTP request and convert it to a <see cref="HandlerContext{T, R}" />
+    /// </summary>
+    /// <typeparam name="T">The request type</typeparam>
+    /// <typeparam name="R">The response type</typeparam>
+    public interface IHttpRequestHandler<T, R>
     {
-        Task<Result<TResponse, Exception>> HandleAsync(HttpContext context,
-            CancellationToken cancelToken);
+        Task<Result<HandlerContext<T, R>, Exception>> HandleAsync(
+            HttpContext context, CancellationToken cancelToken);
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/Json/JsonHttpDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/JsonHttpDecorator.cs
@@ -9,17 +9,17 @@
     /// <summary>
     /// Runs logic on the request/response for json requests
     /// </summary>
-    public class JsonHttpDecorator<TRequest, TResponse> : IHttpRequestHandler<TRequest, TResponse>
+    public class JsonHttpDecorator<T, R> : IHttpRequestHandler<T, R>
     {
-        private readonly IHttpRequestHandler<TRequest, TResponse> inner;
+        private readonly IHttpRequestHandler<T, R> inner;
 
-        public JsonHttpDecorator(IHttpRequestHandler<TRequest, TResponse> inner)
+        public JsonHttpDecorator(IHttpRequestHandler<T, R> inner)
         {
             this.inner = inner.NotNull().Expect(nameof(inner));
         }
 
-        public async Task<Result<TResponse, Exception>> HandleAsync(HttpContext context,
-            CancellationToken cancelToken)
+        public async Task<Result<HandlerContext<T, R>, Exception>> HandleAsync(
+            HttpContext context, CancellationToken cancelToken)
         {
             var validContentType = !string.IsNullOrWhiteSpace(context.Request.ContentType)
                 && context.Request.ContentType.Contains("application/json");
@@ -28,7 +28,7 @@
             {
                 context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
 
-                return Result.Error<TResponse>(
+                return Result.Error<HandlerContext<T, R>>(
                     new BusinessAppWebApiException("Expected content-type to be application/json"));
             }
 

--- a/CSharp/src/BusinessApp.WebApi/Json/NewtonsoftJsonExceptionDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/NewtonsoftJsonExceptionDecorator.cs
@@ -10,20 +10,18 @@ namespace BusinessApp.WebApi.Json
     /// <summary>
     /// Logs certains aspects of a request
     /// </summary>
-    public class NewtonsoftJsonExceptionDecorator<TRequest, TResponse>
-        : IHttpRequestHandler<TRequest, TResponse>
+    public class NewtonsoftJsonExceptionDecorator<T, R> : IHttpRequestHandler<T, R>
     {
-        private readonly IHttpRequestHandler<TRequest, TResponse> inner;
+        private readonly IHttpRequestHandler<T, R> inner;
         private readonly ILogger logger;
 
-        public NewtonsoftJsonExceptionDecorator(IHttpRequestHandler<TRequest, TResponse> inner,
-            ILogger logger)
+        public NewtonsoftJsonExceptionDecorator(IHttpRequestHandler<T, R> inner, ILogger logger)
         {
             this.inner = inner.NotNull().Expect(nameof(inner));
             this.logger = logger.NotNull().Expect(nameof(logger));
         }
 
-        public async Task<Result<TResponse, Exception>> HandleAsync(HttpContext context,
+        public async Task<Result<HandlerContext<T, R>, Exception>> HandleAsync(HttpContext context,
             CancellationToken cancelToken)
         {
             try
@@ -34,7 +32,7 @@ namespace BusinessApp.WebApi.Json
             {
                 Log(exception);
 
-                return Result.Error<TResponse>(
+                return Result.Error<HandlerContext<T, R>>(
                     new BadStateException("Your request could not be read because " +
                         "your payload is in an invalid format. Please review your data " +
                         "and try again"));

--- a/CSharp/src/BusinessApp.WebApi/Json/SystemJsonExceptionDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/SystemJsonExceptionDecorator.cs
@@ -10,21 +10,19 @@ namespace BusinessApp.WebApi.Json
     /// <summary>
     /// Logs certains aspects of a request
     /// </summary>
-    public class SystemJsonExceptionDecorator<TRequest, TResponse>
-        : IHttpRequestHandler<TRequest, TResponse>
+    public class SystemJsonExceptionDecorator<T, R> : IHttpRequestHandler<T, R>
     {
-        private readonly IHttpRequestHandler<TRequest, TResponse> inner;
+        private readonly IHttpRequestHandler<T, R> inner;
         private readonly ILogger logger;
 
-        public SystemJsonExceptionDecorator(IHttpRequestHandler<TRequest, TResponse> inner,
-            ILogger logger)
+        public SystemJsonExceptionDecorator(IHttpRequestHandler<T, R> inner, ILogger logger)
         {
             this.inner = inner.NotNull().Expect(nameof(inner));
             this.logger = logger.NotNull().Expect(nameof(logger));
         }
 
-        public async Task<Result<TResponse, Exception>> HandleAsync(HttpContext context,
-            CancellationToken cancelToken)
+        public async Task<Result<HandlerContext<T, R>, Exception>> HandleAsync(
+            HttpContext context, CancellationToken cancelToken)
         {
             try
             {
@@ -34,7 +32,7 @@ namespace BusinessApp.WebApi.Json
             {
                 Log(exception);
 
-                return Result.Error<TResponse>(
+                return Result.Error<HandlerContext<T, R>>(
                     new BadStateException("Your request could not be read because " +
                         "your payload is in an invalid format. Please review your data " +
                         "and try again"));


### PR DESCRIPTION
* Decorators only have access to the `HttpContext` and the response model.
  Some may need access to the serialized request as well (e.g. Hateoas
  links). Therefore, return a `HandlerContext` the requests and response.
* Change generic names to T & R. R means response and T is your normal
  generic name. Wanted to shorten names because new return type makes
  column length a lot longer

related [AB#5840](https://dev.azure.com/parkeremg/66948845-e870-4cad-a83b-200ec1edb17d/_workitems/edit/5840)