### PR TITLE
refactor(all): Enable nullable warnings

### DIFF
--- a/CSharp/src/BusinessApp.App.IntegrationTest/Json/NewtonsoftJsonSerializerTests.cs
+++ b/CSharp/src/BusinessApp.App.IntegrationTest/Json/NewtonsoftJsonSerializerTests.cs
@@ -44,7 +44,7 @@ namespace BusinessApp.App.IntegrationTest.Json
             }
 
             [Fact]
-            public void OnError_WhenHasMemeberName_ThrowsModelValidationException()
+            public void OnError_WhenHasMemberName_ThrowsModelValidationException()
             {
                 /* Arrange */
                 using var ms = new MemoryStream();
@@ -61,7 +61,7 @@ namespace BusinessApp.App.IntegrationTest.Json
             }
 
             [Fact]
-            public void OnError_HasMemberValidationForEachInvalidMember()
+            public void OnError_HasMultipleMembers_ReturnsEachInvalidMember()
             {
                 /* Arrange */
                 using var ms = new MemoryStream();
@@ -72,9 +72,9 @@ namespace BusinessApp.App.IntegrationTest.Json
 
                 /* Act */
                 var ex = Record.Exception(() => sut.Deserialize<TestModel>(ms.GetBuffer()));
-                var error = Assert.IsType<ModelValidationException>(ex);
 
                 /* Assert */
+                var error = Assert.IsType<ModelValidationException>(ex);
                 Assert.Collection(error,
                     e => Assert.Equal("foo", e.MemberName),
                     e => Assert.Equal("bar", e.MemberName)

--- a/CSharp/src/BusinessApp.App.IntegrationTest/Json/NewtonsoftLongToStringJsonConverterTests.cs
+++ b/CSharp/src/BusinessApp.App.IntegrationTest/Json/NewtonsoftLongToStringJsonConverterTests.cs
@@ -32,10 +32,72 @@ namespace BusinessApp.App.IntegrationTest.Json
             }
         }
 
+        public class ReadJson : NewtonsoftLongToStringJsonConverterTests
+        {
+            [Fact]
+            public void NullToken_NullReturned()
+            {
+                /* Arrange */
+                var reader = A.Fake<JsonReader>();
+                var serializer = A.Dummy<JsonSerializer>();
+                A.CallTo(() => reader.TokenType).Returns(JsonToken.Null);
+
+                /* Act */
+                var readObj = sut.ReadJson(reader,
+                    A.Dummy<Type>(),
+                    A.Dummy<object>(),
+                    serializer);
+
+                /* Assert */
+                Assert.Null(readObj);
+            }
+
+            [Fact]
+            public void LongAsStringValue_LongReturned()
+            {
+                /* Arrange */
+                var reader = A.Fake<JsonReader>();
+                var serializer = A.Dummy<JsonSerializer>();
+                A.CallTo(() => reader.Value).Returns("123");
+
+                /* Act */
+                var readObj = sut.ReadJson(reader,
+                    A.Dummy<Type>(),
+                    A.Dummy<object>(),
+                    serializer);
+
+                /* Assert */
+                var longVal = Assert.IsType<long>(readObj);
+                Assert.Equal(123, longVal);
+            }
+        }
+
         public class WriteJson : NewtonsoftLongToStringJsonConverterTests
         {
             [Fact]
-            public void LongTypeIsString()
+            public void NullType_WritesAsNull()
+            {
+                /* Arrange */
+                StringBuilder sb = new StringBuilder();
+                var sw = new StringWriter(sb);
+                using (var writer = new JsonTextWriter(sw))
+                {
+
+                    var serializer = A.Fake<JsonSerializer>();
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("id");
+
+                    /* Act */
+                    sut.WriteJson(writer, null, serializer);
+                    writer.WriteEnd();
+                }
+
+                /* Assert */
+                Assert.Equal("{\"id\":null}", sb.ToString());
+            }
+
+            [Fact]
+            public void LongType_WritesAsString()
             {
                 /* Arrange */
                 StringBuilder sb = new StringBuilder();

--- a/CSharp/src/BusinessApp.App.UnitTest/AnonymousUserTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/AnonymousUserTests.cs
@@ -9,14 +9,11 @@ namespace BusinessApp.App.UnitTest
 
     public class AnonymousUserTests
     {
-        private readonly AnonymousUser sut;
         private readonly IPrincipal inner;
 
         public AnonymousUserTests()
         {
             inner = A.Fake<IPrincipal>();
-
-            sut = new AnonymousUser(inner);
         }
 
         public class Constructor : AnonymousUserTests
@@ -46,20 +43,20 @@ namespace BusinessApp.App.UnitTest
             }
         }
 
-
         public class IdentityProperty : AnonymousUserTests
         {
             [Fact]
-            public void NullIdentity_EmptyAuthenticationType()
+            public void NullIdentity_NullAuthenticationType()
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity).Returns(null);
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;
 
                 /* Assert */
-                Assert.Empty(identity.AuthenticationType);
+                Assert.Null(identity.AuthenticationType);
             }
 
             [Fact]
@@ -67,6 +64,7 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity).Returns(null);
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;
@@ -80,6 +78,7 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity).Returns(null);
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;
@@ -93,6 +92,7 @@ namespace BusinessApp.App.UnitTest
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity.Name).Returns(null);
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;
@@ -102,10 +102,11 @@ namespace BusinessApp.App.UnitTest
             }
 
             [Fact]
-            public void AuthenticationType_InnerIdentityValueReturned()
+            public void AuthenticationType_InnerValueReturned()
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity.AuthenticationType).Returns("foo");
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;
@@ -117,10 +118,11 @@ namespace BusinessApp.App.UnitTest
             [Theory]
             [InlineData(true)]
             [InlineData(false)]
-            public void IsAuthentication_InnerIdentityValueReturned(bool authenticated)
+            public void IsAuthentication_InnerValueReturned(bool authenticated)
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity.IsAuthenticated).Returns(authenticated);
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;
@@ -132,10 +134,11 @@ namespace BusinessApp.App.UnitTest
             [Theory]
             [InlineData(false, "Anonymous")]
             [InlineData(true, "")]
-            public void Name_AnonymousReturnedIfNameIsEmpty(bool authenticated, string expectedName)
+            public void Name_WhenNameIsEmpty_AnonymousReturned(bool authenticated, string expectedName)
             {
                 /* Arrange */
                 A.CallTo(() => inner.Identity.IsAuthenticated).Returns(authenticated);
+                var sut = new AnonymousUser(inner);
 
                 /* Act */
                 var identity = sut.Identity;

--- a/CSharp/src/BusinessApp.App.UnitTest/AnonymousUserTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/AnonymousUserTests.cs
@@ -89,6 +89,19 @@ namespace BusinessApp.App.UnitTest
             }
 
             [Fact]
+            public void NullIdentityName_AnonymousName()
+            {
+                /* Arrange */
+                A.CallTo(() => inner.Identity.Name).Returns(null);
+
+                /* Act */
+                var identity = sut.Identity;
+
+                /* Assert */
+                Assert.Equal("Anonymous", identity.Name);
+            }
+
+            [Fact]
             public void AuthenticationType_InnerIdentityValueReturned()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.App.UnitTest/BatchRequestAdapterTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/BatchRequestAdapterTests.cs
@@ -47,19 +47,6 @@ namespace BusinessApp.App.UnitTest
         public class HandleAsync : BatchRequestAdapterTests
         {
             [Fact]
-            public async Task WithoutCommandArg_ExceptionThrown()
-            {
-                /* Arrange */
-                Task shouldthrow() => sut.HandleAsync(null, cancelToken);
-
-                /* Act */
-                var ex = await Record.ExceptionAsync(shouldthrow);
-
-                /* Assert */
-                Assert.NotNull(ex);
-            }
-
-            [Fact]
             public async Task WithMultipleCommands_HandlerCalledForEach()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.App.UnitTest/EnvelopeContractTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/EnvelopeContractTests.cs
@@ -1,0 +1,76 @@
+namespace BusinessApp.App.UnitTest
+{
+    using Xunit;
+    using FakeItEasy;
+    using System.Collections.Generic;
+
+    public class EnvelopeContractTests
+    {
+        public class Constructor : EnvelopeContractTests
+        {
+            public static IEnumerable<object[]> InvalidArgs => new[]
+            {
+                new object[] { null, A.Dummy<Pagination>() },
+                new object[] { A.CollectionOfDummy<CommandStub>(0), null },
+            };
+
+            [Theory, MemberData(nameof(InvalidArgs))]
+            public void InvalidArgs_ExceptionThrown(IEnumerable<CommandStub> d, Pagination p)
+            {
+                /* Arrange */
+                void shouldThrow() => new EnvelopeContract<CommandStub>(d, p);
+
+                /* Act */
+                var ex = Record.Exception(shouldThrow);
+
+                /* Assert */
+                Assert.NotNull(ex);
+            }
+
+            [Fact]
+            public void SetsData()
+            {
+                /* Arrange */
+                var stub = new CommandStub();
+
+                /* Act */
+                var sut = new EnvelopeContract<CommandStub>(new[] { stub }, A.Dummy<Pagination>());
+
+                /* Assert */
+                Assert.Collection(sut.Data, d => Assert.Same(stub, d));
+            }
+
+            [Fact]
+            public void SetsPagination()
+            {
+                /* Arrange */
+                var page = new Pagination();
+
+                /* Act */
+                var sut = new EnvelopeContract<CommandStub>(A.CollectionOfDummy<CommandStub>(0), page);
+
+                /* Assert */
+                Assert.Same(page, sut.Pagination);
+            }
+        }
+
+        public class IEnumerableImpl : EnvelopeContractTests
+        {
+            [Fact]
+            public void ReturnsDataEnumerator()
+            {
+                /* Arrange */
+                var expectEnumerator = A.Fake<IEnumerator<CommandStub>>();
+                var data = A.Fake<IEnumerable<CommandStub>>();
+                var sut = new EnvelopeContract<CommandStub>(data, A.Dummy<Pagination>());
+                A.CallTo(() => data.GetEnumerator()).Returns(expectEnumerator);
+
+                /* Act */
+                var actualEnumerator = sut.GetEnumerator();
+
+                /* Assert */
+                Assert.Same(expectEnumerator, actualEnumerator);
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.App.UnitTest/GroupedBatchRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/GroupedBatchRequestDecoratorTests.cs
@@ -61,19 +61,6 @@ namespace BusinessApp.App.UnitTest
         public class HandleAsync : GroupedBatchRequestDecoratorTests
         {
             [Fact]
-            public async Task WithoutCommand_ExceptionThrown()
-            {
-                /* Arrange */
-                Task shouldthrow() => sut.HandleAsync(null, A.Dummy<CancellationToken>());
-
-                /* Act */
-                var ex = await Record.ExceptionAsync(shouldthrow);
-
-                /* Assert */
-                Assert.NotNull(ex);
-            }
-
-            [Fact]
             public async Task WithCommand_HandlerCalledPerGroup()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.App.UnitTest/MacroBatchRequestAdapterTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/MacroBatchRequestAdapterTests.cs
@@ -60,19 +60,6 @@ namespace BusinessApp.App.UnitTest
         public class HandleAsync : MacroBatchRequestAdapterTests
         {
             [Fact]
-            public async Task WithoutCommandArg_ExceptionThrown()
-            {
-                /* Arrange */
-                Task shouldthrow() => sut.HandleAsync(null, A.Dummy<CancellationToken>());
-
-                /* Act */
-                var ex = await Record.ExceptionAsync(shouldthrow);
-
-                /* Assert */
-                Assert.NotNull(ex);
-            }
-
-            [Fact]
             public async Task NoReturnedPayloadsFromMacro_ExceptionThrown()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.App.UnitTest/SerializedLogEntryFormatterTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/SerializedLogEntryFormatterTests.cs
@@ -84,7 +84,10 @@ namespace BusinessApp.App.UnitTest
             public void WithEntry_DataSerialized()
             {
                 object data = new {};
-                var entry = new LogEntry(LogSeverity.Info, "foobar", null, data);
+                var entry = new LogEntry(LogSeverity.Info, "foobar")
+                {
+                    Data = data
+                };
 
                 var formatted = sut.Format(entry);
 
@@ -95,7 +98,10 @@ namespace BusinessApp.App.UnitTest
             public void WithOneExceptionEntry_ExceptionMessageSerialized()
             {
                 var exception = new Exception("foobar");
-                var entry = new LogEntry(LogSeverity.Info, "foobar", exception);
+                var entry = new LogEntry(LogSeverity.Info, "foobar")
+                {
+                    Exception = exception
+                };
 
                 var formatted = sut.Format(entry);
 
@@ -108,7 +114,10 @@ namespace BusinessApp.App.UnitTest
             public void WithOneExceptionEntry_ExceptionHResultSerialized()
             {
                 var exception = new Exception();
-                var entry = new LogEntry(LogSeverity.Info, "foobar", exception);
+                var entry = new LogEntry(LogSeverity.Info, "foobar")
+                {
+                    Exception = exception
+                };
 
                 var formatted = sut.Format(entry);
 
@@ -121,7 +130,10 @@ namespace BusinessApp.App.UnitTest
             public void WithOneExceptionEntry_ExceptionSourceSerialized()
             {
                 var exception = new Exception();
-                var entry = new LogEntry(LogSeverity.Info, "foobar", exception);
+                var entry = new LogEntry(LogSeverity.Info, "foobar")
+                {
+                    Exception = exception
+                };
 
                 var formatted = sut.Format(entry);
 
@@ -136,7 +148,10 @@ namespace BusinessApp.App.UnitTest
             public void WithOneExceptionEntry_ExceptionStackTraceSerialized()
             {
                 var exception = new Exception();
-                var entry = new LogEntry(LogSeverity.Info, "foobar", exception);
+                var entry = new LogEntry(LogSeverity.Info, "foobar")
+                {
+                    Exception = exception
+                };
 
                 var formatted = sut.Format(entry);
 
@@ -152,7 +167,10 @@ namespace BusinessApp.App.UnitTest
             {
                 var inner = new Exception("bar");
                 var exception = new Exception("foo", inner);
-                var entry = new LogEntry(LogSeverity.Info, "foobar", exception);
+                var entry = new LogEntry(LogSeverity.Info, "foobar")
+                {
+                    Exception = exception
+                };
 
                 var formatted = sut.Format(entry);
 
@@ -185,7 +203,11 @@ namespace BusinessApp.App.UnitTest
             [Fact]
             public void WithMultipleEntries_SeriazliedOnce()
             {
-                var entry = new LogEntry(LogSeverity.Info, "foo", new Exception(), new {});
+                var entry = new LogEntry(LogSeverity.Info, "foo")
+                {
+                    Exception = new Exception(),
+                    Data = new {}
+                };
 
                 sut.Format(entry);
                 sut.Format(entry);

--- a/CSharp/src/BusinessApp.App.UnitTest/StringLogEntryFormatterTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/StringLogEntryFormatterTests.cs
@@ -27,7 +27,7 @@ namespace BusinessApp.App.UnitTest
             public void WithEntry_CallsEntryToString()
             {
                 var entry = A.Fake<LogEntry>(opt =>
-                    opt.WithArgumentsForConstructor(new object[] { LogSeverity.Debug, "", null, null }));
+                    opt.WithArgumentsForConstructor(new object[] { LogSeverity.Debug, "msg" }));
 
                 var formatted = sut.Format(entry);
 

--- a/CSharp/src/BusinessApp.App.UnitTest/TransactionRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.App.UnitTest/TransactionRequestDecoratorTests.cs
@@ -71,19 +71,6 @@ namespace BusinessApp.App.UnitTest
         public class HandleAsync : TransactionDecoratorTests
         {
             [Fact]
-            public async Task NullCommand_ExceptionThrown()
-            {
-                /* Arrange */
-                Task shouldthrow() => sut.HandleAsync(null, A.Dummy<CancellationToken>());
-
-                /* Act */
-                var ex = await Record.ExceptionAsync(shouldthrow);
-
-                /* Assert */
-                Assert.IsType<BadStateException>(ex);
-            }
-
-            [Fact]
             public async Task BeforeRegister_TransFactoryAndHandlerCalledInOrder()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.App/AnonymousUser.cs
+++ b/CSharp/src/BusinessApp.App/AnonymousUser.cs
@@ -4,10 +4,12 @@ namespace BusinessApp.App
     using BusinessApp.Domain;
 
     /// <summary>
-    /// Http user implementation of the IPrincipal
+    /// <see cref="IPrincipal" /> implementation for an anonymous user
     /// </summary>
     public class AnonymousUser : IPrincipal
     {
+        public const string Name = "Anonymous";
+
         private readonly IPrincipal inner;
         private readonly IIdentity identity;
 
@@ -23,16 +25,18 @@ namespace BusinessApp.App
 
         private class AnonymousIdentity : IIdentity
         {
-            private readonly IIdentity inner;
+            private readonly IIdentity? inner;
 
-            public AnonymousIdentity(IIdentity inner)
+            public AnonymousIdentity(IIdentity? inner)
             {
                 this.inner = inner;
             }
 
-            public string AuthenticationType => inner?.AuthenticationType;
+            public string? AuthenticationType => inner?.AuthenticationType;
             public bool IsAuthenticated => inner?.IsAuthenticated ?? false;
-            public string Name => !IsAuthenticated ? "Anonymous" : inner.Name;
+            public string Name => !IsAuthenticated
+                ? AnonymousUser.Name
+                : (inner?.Name ?? AnonymousUser.Name);
         }
     }
 }

--- a/CSharp/src/BusinessApp.App/AuthorizationRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.App/AuthorizationRequestDecorator.cs
@@ -6,6 +6,7 @@
     using BusinessApp.Domain;
 
     public class AuthorizationRequestDecorator<TRequest, TResult> : IRequestHandler<TRequest, TResult>
+        where TRequest : notnull
     {
         private readonly IRequestHandler<TRequest, TResult> inner;
         private readonly IAuthorizer<TRequest> authorizer;

--- a/CSharp/src/BusinessApp.App/BatchException.cs
+++ b/CSharp/src/BusinessApp.App/BatchException.cs
@@ -34,7 +34,7 @@ namespace BusinessApp.App
                     default:
                         allResults.Add(result.MapOrElse(
                             e => Result.Error<object>(e),
-                            v => Result.Ok<object>(v)
+                            v => Result.Ok<object>(v!)
                         ));
                         break;
                 };

--- a/CSharp/src/BusinessApp.App/BatchRequestAdapter.cs
+++ b/CSharp/src/BusinessApp.App/BatchRequestAdapter.cs
@@ -9,6 +9,7 @@
 
     public class BatchRequestAdapter<TRequest, TResponse>
         : IRequestHandler<IEnumerable<TRequest>, IEnumerable<TResponse>>
+        where TRequest : notnull
     {
         private readonly IRequestHandler<TRequest, TResponse> inner;
 
@@ -21,8 +22,6 @@
             IEnumerable<TRequest> request,
             CancellationToken cancelToken)
         {
-            request.NotNull().Expect(nameof(request));
-
             var results = new List<Result<TResponse, Exception>>();
 
             foreach(var msg in request)

--- a/CSharp/src/BusinessApp.App/BusinessApp.App.csproj
+++ b/CSharp/src/BusinessApp.App/BusinessApp.App.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharp/src/BusinessApp.App/BusinessAppAppException.cs
+++ b/CSharp/src/BusinessApp.App/BusinessAppAppException.cs
@@ -9,7 +9,7 @@ namespace BusinessApp.App
     [Serializable]
     public class BusinessAppAppException : BusinessAppException
     {
-        public BusinessAppAppException(string message, Exception inner = null)
+        public BusinessAppAppException(string message, Exception? inner = null)
             :base(message, inner)
         { }
     }

--- a/CSharp/src/BusinessApp.App/CommunicationException.cs
+++ b/CSharp/src/BusinessApp.App/CommunicationException.cs
@@ -5,7 +5,7 @@ namespace BusinessApp.App
     [Serializable]
     public class CommunicationException : Exception
     {
-        public CommunicationException(string message, Exception inner = null)
+        public CommunicationException(string message, Exception? inner = null)
             :base(message, inner)
         {
             Data.Add("", message);

--- a/CSharp/src/BusinessApp.App/CompositeValidator.cs
+++ b/CSharp/src/BusinessApp.App/CompositeValidator.cs
@@ -10,6 +10,7 @@ namespace BusinessApp.App
     /// Runs multiple validators for one instance of <typeparam name="T">T</typeparam>
     /// </summary>
     public class CompositeValidator<T> : IValidator<T>
+        where T : notnull
     {
         private readonly IEnumerable<IValidator<T>> validators;
 

--- a/CSharp/src/BusinessApp.App/DataAnnotationsValidator.cs
+++ b/CSharp/src/BusinessApp.App/DataAnnotationsValidator.cs
@@ -35,7 +35,6 @@
                     throw new BusinessAppAppException("All errors must have an error message.");
                 }
 
-
                 var memberMsgs = (members.Any() ? members : new[] { "" })
                     .ToDictionary(
                         m => m,

--- a/CSharp/src/BusinessApp.App/DataAnnotationsValidator.cs
+++ b/CSharp/src/BusinessApp.App/DataAnnotationsValidator.cs
@@ -12,6 +12,7 @@
     /// Runs validations for data annotations
     /// </summary>
     public class DataAnnotationsValidator<T> : IValidator<T>
+        where T : notnull
     {
         public Task<Result<Unit, Exception>> ValidateAsync(T instance, CancellationToken cancelToken)
         {
@@ -29,10 +30,16 @@
                         "If the attribute does not support this, please create or extend the attribute");
                 }
 
+                if (errors.Any(e => e.ErrorMessage == null))
+                {
+                    throw new BusinessAppAppException("All errors must have an error message.");
+                }
+
+
                 var memberMsgs = (members.Any() ? members : new[] { "" })
                     .ToDictionary(
                         m => m,
-                        m => errors.Where(e => e.MemberNames.Contains(m)).Select(e => e.ErrorMessage));
+                        m => errors.Where(e => e.MemberNames.Contains(m)).Select(e => e.ErrorMessage!));
 
                 return Task.FromResult(
                     Result.Error(

--- a/CSharp/src/BusinessApp.App/DeadlockRetryRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.App/DeadlockRetryRequestDecorator.cs
@@ -11,6 +11,7 @@ namespace BusinessApp.App
     /// </summary>
     public class DeadlockRetryRequestDecorator<TRequest, TResponse> :
         IRequestHandler<TRequest, TResponse>
+        where TRequest : notnull
     {
         private readonly IRequestHandler<TRequest, TResponse> decoratee;
         private readonly int sleepBetweenRetries = 500;

--- a/CSharp/src/BusinessApp.App/EntityNotFoundException.cs
+++ b/CSharp/src/BusinessApp.App/EntityNotFoundException.cs
@@ -14,7 +14,7 @@
             Data.Add("", message);
         }
 
-        public EntityNotFoundException(string entityName, string message = null)
+        public EntityNotFoundException(string entityName, string? message = null)
             :base(message ?? $"{entityName} not found")
         {
             Data.Add(entityName, message);

--- a/CSharp/src/BusinessApp.App/EntityNotFoundQueryDecorator.cs
+++ b/CSharp/src/BusinessApp.App/EntityNotFoundQueryDecorator.cs
@@ -9,7 +9,7 @@
     /// Throws a business exception if no entity is found from the query
     /// </summary>
     public class EntityNotFoundQueryDecorator<TQuery, TResult> : IRequestHandler<TQuery, TResult>
-        where TQuery : IQuery
+        where TQuery : notnull, IQuery
     {
         private readonly IRequestHandler<TQuery, TResult> decorated;
 

--- a/CSharp/src/BusinessApp.App/EnvelopeContract.cs
+++ b/CSharp/src/BusinessApp.App/EnvelopeContract.cs
@@ -2,15 +2,19 @@ namespace BusinessApp.App
 {
     using System.Collections;
     using System.Collections.Generic;
+    using BusinessApp.Domain;
 
     public class EnvelopeContract<TData> : IEnumerable<TData>
     {
-        public IEnumerable<TData> Data { get; set; }
+        public EnvelopeContract(IEnumerable<TData> data, Pagination pagination)
+        {
+            Data = data.NotNull().Expect(nameof(data));
+            Pagination = pagination.NotNull().Expect(nameof(data));
+        }
 
-        public Pagination Pagination { get; set; }
-
+        public IEnumerable<TData> Data { get; }
+        public Pagination Pagination { get; }
         public IEnumerator<TData> GetEnumerator() => Data.GetEnumerator();
-
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }

--- a/CSharp/src/BusinessApp.App/EventConsumingRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.App/EventConsumingRequestDecorator.cs
@@ -18,7 +18,7 @@ namespace BusinessApp.App
         where TRequest : class
         where TResponse : IEventStream
     {
-        private static MethodInfo PublishMethod = typeof(IEventPublisher).GetMethod(nameof(IEventPublisher.PublishAsync));
+        private static MethodInfo PublishMethod = typeof(IEventPublisher).GetMethod(nameof(IEventPublisher.PublishAsync))!;
         private readonly IEventPublisherFactory publisherFactory;
         private readonly IRequestHandler<TRequest, TResponse> inner;
 
@@ -75,7 +75,7 @@ namespace BusinessApp.App
             var generic = PublishMethod.MakeGenericMethod(@event.GetType());
 
             return (Task<EventResult>)generic.Invoke(publisher,
-                new object[] { @event, cancelToken });
+                new object[] { @event, cancelToken })!;
         }
     }
 }

--- a/CSharp/src/BusinessApp.App/EventMetadataPublisherFactory.cs
+++ b/CSharp/src/BusinessApp.App/EventMetadataPublisherFactory.cs
@@ -57,7 +57,7 @@ namespace BusinessApp.App
             {
                 var publishedTrackingId = store.Add(published);
 
-                if (outcomeTracking.TryGetValue(published, out EventTrackingId causedById))
+                if (outcomeTracking.TryGetValue(published, out EventTrackingId? causedById))
                 {
                     publishedTrackingId.CausationId = causedById.Id;
                 }

--- a/CSharp/src/BusinessApp.App/FluentValidationValidator.cs
+++ b/CSharp/src/BusinessApp.App/FluentValidationValidator.cs
@@ -11,6 +11,7 @@ namespace BusinessApp.App
     /// Runs validations for any fluent validation rules
     /// </summary>
     public class FluentValidationValidator<T> : IValidator<T>
+        where T : notnull
     {
         private readonly IEnumerable<FluentValidation.IValidator<T>> validators;
 

--- a/CSharp/src/BusinessApp.App/GroupedBatchRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.App/GroupedBatchRequestDecorator.cs
@@ -9,6 +9,7 @@ namespace BusinessApp.App
 
     public class GroupedBatchRequestDecorator<TRequest, TResponse>
         : IRequestHandler<IEnumerable<TRequest>, IEnumerable<TResponse>>
+        where TRequest : notnull
     {
         private readonly IBatchGrouper<TRequest> grouper;
         private readonly IRequestHandler<IEnumerable<TRequest>, IEnumerable<TResponse>> handler;
@@ -25,8 +26,6 @@ namespace BusinessApp.App
             IEnumerable<TRequest> request,
             CancellationToken cancelToken)
         {
-            request.NotNull().Expect(nameof(request));
-
             var payloads = await grouper.GroupAsync(request, cancelToken);
 
             ThrowIfInvalid(request, payloads.SelectMany(p => p));

--- a/CSharp/src/BusinessApp.App/IAuthorizer.cs
+++ b/CSharp/src/BusinessApp.App/IAuthorizer.cs
@@ -4,6 +4,7 @@ namespace BusinessApp.App
     /// Interface to authorize the execution of the instance
     /// </summary>
     public interface IAuthorizer<T>
+        where T : notnull
     {
         void AuthorizeObject(T instance);
     }

--- a/CSharp/src/BusinessApp.App/IBatchGrouper.cs
+++ b/CSharp/src/BusinessApp.App/IBatchGrouper.cs
@@ -8,6 +8,7 @@ namespace BusinessApp.App
     /// Consolidate batch requests into units of work
     /// </summary>
     public interface IBatchGrouper<TCommand>
+        where TCommand : notnull
     {
         /// <summary>
         /// Groups the <paramref name="commands"/>

--- a/CSharp/src/BusinessApp.App/IBatchMacro.cs
+++ b/CSharp/src/BusinessApp.App/IBatchMacro.cs
@@ -8,7 +8,7 @@ namespace BusinessApp.App
     /// Consolidate batch requests into units of work
     /// </summary>
     public interface IBatchMacro<TMacro, TCommand>
-        where TMacro :IMacro<TCommand>
+        where TMacro : notnull, IMacro<TCommand>
     {
         /// <summary>
         /// Groups the <paramref name="commands"/>

--- a/CSharp/src/BusinessApp.App/IMacro.cs
+++ b/CSharp/src/BusinessApp.App/IMacro.cs
@@ -4,6 +4,5 @@ namespace BusinessApp.App
     /// Command that expands to running many <typeparam name="TCommand">TCommand</typeparam>
     /// </summary>
     public interface IMacro<TCommand>
-    {
-    }
+    { }
 }

--- a/CSharp/src/BusinessApp.App/IRequest.cs
+++ b/CSharp/src/BusinessApp.App/IRequest.cs
@@ -6,6 +6,7 @@ namespace BusinessApp.App
     /// <typeparam name="TResult">
     /// The result set type returned from the query
     /// </typeparam>
+    [System.Obsolete]
     public interface IRequest<out TResponse>
     {
     }

--- a/CSharp/src/BusinessApp.App/IRequest.cs
+++ b/CSharp/src/BusinessApp.App/IRequest.cs
@@ -6,7 +6,6 @@ namespace BusinessApp.App
     /// <typeparam name="TResult">
     /// The result set type returned from the query
     /// </typeparam>
-    [System.Obsolete]
     public interface IRequest<out TResponse>
     {
     }

--- a/CSharp/src/BusinessApp.App/IRequestHandler.cs
+++ b/CSharp/src/BusinessApp.App/IRequestHandler.cs
@@ -6,6 +6,7 @@ namespace BusinessApp.App
     using BusinessApp.Domain;
 
     public interface IRequestHandler<in TRequest, TResponse>
+        where TRequest : notnull
     {
         Task<Result<TResponse, Exception>> HandleAsync(TRequest request,
             CancellationToken cancelToken);

--- a/CSharp/src/BusinessApp.App/ISerializer.cs
+++ b/CSharp/src/BusinessApp.App/ISerializer.cs
@@ -2,7 +2,7 @@
 {
     public interface ISerializer
     {
-        T Deserialize<T>(byte[] data);
+        T? Deserialize<T>(byte[] data);
         byte[] Serialize<T>(T graph);
     }
 }

--- a/CSharp/src/BusinessApp.App/IValidator.cs
+++ b/CSharp/src/BusinessApp.App/IValidator.cs
@@ -9,6 +9,7 @@
     /// Interface to validate the data from an instance <typeparam name="T">T</typeparam>
     /// </summary>
     public interface IValidator<T>
+        where T : notnull
     {
         /// <summary>
         /// Validates the instance, returning a result indicating success or failure

--- a/CSharp/src/BusinessApp.App/InstanceCacheQueryDecorator.cs
+++ b/CSharp/src/BusinessApp.App/InstanceCacheQueryDecorator.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.App
     /// Caches the query results for the lifetime of the class
     /// </summary>
     public class InstanceCacheQueryDecorator<TQuery, TResult> : IRequestHandler<TQuery, TResult>
-        where TQuery : IQuery
+        where TQuery : notnull, IQuery
     {
         private readonly ConcurrentDictionary<TQuery, Result<TResult, Exception>> cache;
         private readonly IRequestHandler<TQuery, TResult> inner;

--- a/CSharp/src/BusinessApp.App/Json/NewtonsoftEntityIdJsonConverter.cs
+++ b/CSharp/src/BusinessApp.App/Json/NewtonsoftEntityIdJsonConverter.cs
@@ -16,7 +16,7 @@
             typeof(IEntityId).IsAssignableFrom(objectType) ||
             typeof(IEntityId).IsAssignableFrom(Nullable.GetUnderlyingType(objectType));
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue,
             JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null || reader.Value == null) return null;
@@ -25,13 +25,15 @@
 
             try
             {
-                if (CanTryToConvertNumber(reader, converter, out Type typeToConvertTo))
+                if (CanTryToConvertNumber(reader, converter, out Type? typeToConvertTo))
                 {
                     var longConverter = TypeDescriptor.GetConverter(typeof(long));
 
-                    return converter.ConvertFrom(longConverter.ConvertTo(reader.Value, typeToConvertTo));
+                    return converter.ConvertFrom(
+                        longConverter.ConvertTo(reader.Value, typeToConvertTo));
                 }
-                if (converter.CanConvertTo(reader.ValueType) || CanTryToConvertNumber(reader, converter, out Type _))
+                if (converter.CanConvertTo(reader.ValueType)
+                    || CanTryToConvertNumber(reader, converter, out Type _))
                 {
                         return converter.ConvertFrom(reader.Value);
                 }
@@ -44,7 +46,7 @@
             throw new BusinessAppAppException(string.Format(ErrTemplate, reader.Path));
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             if (value is IEntityId id)
             {
@@ -60,7 +62,7 @@
         }
 
         // all json values are long, so we need to convert to actual type
-        private static bool CanTryToConvertNumber(JsonReader reader, TypeConverter converter, out Type typeToConvertTo)
+        private static bool CanTryToConvertNumber(JsonReader reader, TypeConverter converter, out Type? typeToConvertTo)
         {
             typeToConvertTo = null;
 

--- a/CSharp/src/BusinessApp.App/Json/NewtonsoftJsonSerializer.cs
+++ b/CSharp/src/BusinessApp.App/Json/NewtonsoftJsonSerializer.cs
@@ -24,28 +24,29 @@ namespace BusinessApp.App.Json
             this.logger = logger.NotNull().Expect(nameof(logger));
             this.settings = settings.NotNull().Expect(nameof(logger));
             serializer = JsonSerializer.Create(settings);
+            errors = new List<MemberValidationException>();
         }
 
-        public T Deserialize<T>(byte[] data)
+        public T? Deserialize<T>(byte[] data)
         {
-            using var serializationStream = new MemoryStream(data);
             errors = new List<MemberValidationException>();
             serializer.Error += OnError;
-            using (var sr = new StreamReader(serializationStream))
-            using (var jr = new JsonTextReader(sr))
+
+            using var serializationStream = new MemoryStream(data);
+            using var sr = new StreamReader(serializationStream);
+            using var jr = new JsonTextReader(sr);
+
+            try
             {
-                try
-                {
-                    var model =  serializer.Deserialize<T>(jr);
+                var model =  serializer.Deserialize<T>(jr);
 
-                    if (!errors.Any()) return model;
+                if (!errors.Any()) return model;
 
-                    throw new ModelValidationException("There is bad data", errors);
-                }
-                finally
-                {
-                    serializer.Error -= OnError;
-                }
+                throw new ModelValidationException("There is bad data", errors);
+            }
+            finally
+            {
+                serializer.Error -= OnError;
             }
         }
 
@@ -56,26 +57,26 @@ namespace BusinessApp.App.Json
             return Encoding.UTF8.GetBytes(str);
         }
 
-        private void OnError(object sender, ErrorEventArgs e)
+        private void OnError(object? sender, ErrorEventArgs e)
         {
-            if (e.ErrorContext.Member != null)
+            ErrorEventArgs args = e;
+
+            if (args.ErrorContext.Member != null)
             {
                 var error = new MemberValidationException(
-                    e.ErrorContext.Member?.ToString(),
-                    new[] { e.ErrorContext.Error.Message });
+                    args.ErrorContext.Member.ToString()!,
+                    new[] { args.ErrorContext.Error.Message });
 
                 errors.Add(error);
 
-                e.ErrorContext.Handled = true;
+                args.ErrorContext.Handled = true;
             }
 
-            logger.Log(
-                new LogEntry(
-                    LogSeverity.Error,
-                    "Deserialization failed",
-                    e.ErrorContext.Error,
-                    e.ErrorContext.OriginalObject)
-            );
+            logger.Log(new LogEntry(LogSeverity.Error, "Deserialization failed")
+            {
+                Exception = args.ErrorContext.Error,
+                Data = args.ErrorContext.OriginalObject
+            });
         }
     }
 }

--- a/CSharp/src/BusinessApp.App/Json/NewtonsoftJsonSerializer.cs
+++ b/CSharp/src/BusinessApp.App/Json/NewtonsoftJsonSerializer.cs
@@ -60,11 +60,11 @@ namespace BusinessApp.App.Json
         private void OnError(object? sender, ErrorEventArgs e)
         {
             ErrorEventArgs args = e;
+            var memberName = args.ErrorContext.Member?.ToString();
 
-            if (args.ErrorContext.Member != null)
+            if (!string.IsNullOrWhiteSpace(memberName))
             {
-                var error = new MemberValidationException(
-                    args.ErrorContext.Member.ToString()!,
+                var error = new MemberValidationException(memberName,
                     new[] { args.ErrorContext.Error.Message });
 
                 errors.Add(error);

--- a/CSharp/src/BusinessApp.App/Json/NewtonsoftLongToStringJsonConverter.cs
+++ b/CSharp/src/BusinessApp.App/Json/NewtonsoftLongToStringJsonConverter.cs
@@ -11,17 +11,21 @@ namespace BusinessApp.App.Json
     {
         public override bool CanConvert(Type objectType) => objectType == typeof(long);
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue,
+            JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.Null) return null;
 
             return Convert.ToInt64(reader.Value);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
-            var finalValue = JToken.FromObject(value?.ToString());
-            finalValue.WriteTo(writer);
+            if (value != null)
+            {
+                var finalValue = JToken.FromObject(value.ToString()!);
+                finalValue.WriteTo(writer);
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.App/Json/SystemEntityIdJsonConverter.cs
+++ b/CSharp/src/BusinessApp.App/Json/SystemEntityIdJsonConverter.cs
@@ -20,7 +20,7 @@ namespace BusinessApp.App.Json
             var converterType = typeof(SystemEntityIdJsonConverter<>)
                 .MakeGenericType(typeToConvert);
 
-            return (JsonConverter)Activator.CreateInstance(converterType);
+            return (JsonConverter)Activator.CreateInstance(converterType)!;
         }
 
         private class SystemEntityIdJsonConverter<TEntityId> : JsonConverter<TEntityId>
@@ -28,10 +28,10 @@ namespace BusinessApp.App.Json
         {
             private static string TypeDisplayName = typeof(TEntityId).Name;
 
-            public override TEntityId Read(ref Utf8JsonReader reader, Type typeToConvert,
+            public override TEntityId? Read(ref Utf8JsonReader reader, Type typeToConvert,
                 JsonSerializerOptions options)
             {
-                if (reader.TokenType == JsonTokenType.Null) return default(TEntityId);
+                if (reader.TokenType == JsonTokenType.Null) return default;
 
                 var converter = TypeDescriptor.GetConverter(typeToConvert);
 
@@ -40,7 +40,7 @@ namespace BusinessApp.App.Json
                 {
                     return (TEntityId)converter.ConvertFrom(reader.GetString());
                 }
-                else if (CanTryToConvertNumber(reader, converter, out Type typeToConvertTo))
+                else if (CanTryToConvertNumber(reader, converter, out Type? typeToConvertTo))
                 {
                     var longConverter = TypeDescriptor.GetConverter(typeof(long));
 
@@ -67,8 +67,9 @@ namespace BusinessApp.App.Json
                 }
             }
 
-        // all json values are long, so we need to convert to actual type
-        private static bool CanTryToConvertNumber(Utf8JsonReader reader, TypeConverter converter, out Type typeToConvertTo)
+            // all json values are long, so we need to convert to actual type
+            private static bool CanTryToConvertNumber(Utf8JsonReader reader, TypeConverter converter,
+                out Type? typeToConvertTo)
             {
                 typeToConvertTo = null;
 

--- a/CSharp/src/BusinessApp.App/Json/SystemJsonSerializerAdapter.cs
+++ b/CSharp/src/BusinessApp.App/Json/SystemJsonSerializerAdapter.cs
@@ -16,7 +16,7 @@ namespace BusinessApp.App.Json
             this.options = options.NotNull().Expect(nameof(options));
         }
 
-        public T Deserialize<T>(byte[] data)
+        public T? Deserialize<T>(byte[] data)
         {
             return data.Length > 0 ?
                 JsonSerializer.Deserialize<T>(data.AsSpan(), options) :

--- a/CSharp/src/BusinessApp.App/Json/SystemLongToStringJsonConverter.cs
+++ b/CSharp/src/BusinessApp.App/Json/SystemLongToStringJsonConverter.cs
@@ -1,4 +1,4 @@
-namespace BusinessApp.WebApi.Json
+namespace BusinessApp.App.Json
 {
     using System;
     using System.Buffers;

--- a/CSharp/src/BusinessApp.App/MacroBatchRequestAdapter.cs
+++ b/CSharp/src/BusinessApp.App/MacroBatchRequestAdapter.cs
@@ -25,8 +25,6 @@ namespace BusinessApp.App
         public async Task<Result<TResponse, Exception>> HandleAsync(TMacro macro,
             CancellationToken cancelToken)
         {
-            macro.NotNull().Expect(nameof(macro));
-
             var payloads = await expander.ExpandAsync(macro, cancelToken);
 
             if (!payloads.Any())

--- a/CSharp/src/BusinessApp.App/NoBusinessLogicRequestHandler.cs
+++ b/CSharp/src/BusinessApp.App/NoBusinessLogicRequestHandler.cs
@@ -15,6 +15,7 @@ namespace BusinessApp.App
     /// </remarks>
     public class NoBusinessLogicRequestHandler<TRequest> :
         IRequestHandler<TRequest, TRequest>
+        where TRequest : notnull
     {
         public Task<Result<TRequest, Exception>> HandleAsync(TRequest request,
             CancellationToken cancelToken)

--- a/CSharp/src/BusinessApp.App/NullBatchGrouper.cs
+++ b/CSharp/src/BusinessApp.App/NullBatchGrouper.cs
@@ -5,6 +5,7 @@ namespace BusinessApp.App
     using System.Threading.Tasks;
 
     public class NullBatchGrouper<TCommand> : IBatchGrouper<TCommand>
+        where TCommand : notnull
     {
         public Task<IEnumerable<IEnumerable<TCommand>>> GroupAsync(IEnumerable<TCommand> commands,
             CancellationToken cancelToken)

--- a/CSharp/src/BusinessApp.App/QueryOperatorAttribute.cs
+++ b/CSharp/src/BusinessApp.App/QueryOperatorAttribute.cs
@@ -25,7 +25,7 @@ namespace BusinessApp.App
             TargetProp = targetProp.NotEmpty().Expect(nameof(targetProp));
         }
 
-        public string OperatorToUse { get; }
+        public string? OperatorToUse { get; }
         public string TargetProp { get; }
     }
 }

--- a/CSharp/src/BusinessApp.App/RequestExceptionDecorator.cs
+++ b/CSharp/src/BusinessApp.App/RequestExceptionDecorator.cs
@@ -7,9 +7,10 @@ namespace BusinessApp.App
 
     /// <summary>
     /// Handles uncaught errors during handling so it can transform the response into
-    /// a <see cref="ValueKind"/> type
+    /// a <see cref="Result"/> type
     /// </summary>
     public class RequestExceptionDecorator<TRequest, TResponse> : IRequestHandler<TRequest, TResponse>
+        where TRequest : notnull
     {
         private readonly IRequestHandler<TRequest, TResponse> inner;
         private readonly ILogger logger;
@@ -30,7 +31,11 @@ namespace BusinessApp.App
             }
             catch(Exception e)
             {
-                logger.Log(new LogEntry(LogSeverity.Critical, e.Message, e, request));
+                logger.Log(new LogEntry(LogSeverity.Critical, e.Message)
+                {
+                    Exception = e,
+                    Data = request
+                });
 
                 return Result.Error<TResponse>(e);
             }

--- a/CSharp/src/BusinessApp.App/ScopedBatchRequestProxy.cs
+++ b/CSharp/src/BusinessApp.App/ScopedBatchRequestProxy.cs
@@ -8,6 +8,7 @@ namespace BusinessApp.App
 
     public class ScopedBatchRequestProxy<TRequest, TResponse>
         : IRequestHandler<IEnumerable<TRequest>, TResponse>
+        where TRequest : notnull
     {
         private readonly IAppScope scope;
         private readonly Func<IRequestHandler<IEnumerable<TRequest>, TResponse>> factory;

--- a/CSharp/src/BusinessApp.App/SecurityResourceException.cs
+++ b/CSharp/src/BusinessApp.App/SecurityResourceException.cs
@@ -6,7 +6,7 @@ namespace BusinessApp.App
 
     public class SecurityResourceException : SecurityException
     {
-        public SecurityResourceException(string resourceName, string message, Exception inner = null)
+        public SecurityResourceException(string resourceName, string message, Exception? inner = null)
             :base(message, inner)
         {
             ResourceName = resourceName.NotEmpty().Expect(nameof(resourceName));

--- a/CSharp/src/BusinessApp.App/SerializedLogEntryFormatter.cs
+++ b/CSharp/src/BusinessApp.App/SerializedLogEntryFormatter.cs
@@ -23,7 +23,7 @@ namespace BusinessApp.App
         {
             entry.NotNull().Expect(nameof(entry));
 
-            if (messageCache.TryGetValue(entry, out string msg))
+            if (messageCache.TryGetValue(entry, out string? msg))
             {
                 return msg;
             }

--- a/CSharp/src/BusinessApp.App/SingleQueryRequestAdapter.cs
+++ b/CSharp/src/BusinessApp.App/SingleQueryRequestAdapter.cs
@@ -17,7 +17,7 @@ namespace BusinessApp.App
     /// </remarks>
     public class SingleQueryRequestAdapter<TRequest, TResponse> :
         IRequestHandler<TRequest, TResponse>
-        where TRequest : IQuery
+        where TRequest : notnull, IQuery
     {
         private static Exception MoreThanOneResultErr =
             new BusinessAppAppException("Your query expected to return one result, but " +

--- a/CSharp/src/BusinessApp.App/ValidateObjectAttribute.cs
+++ b/CSharp/src/BusinessApp.App/ValidateObjectAttribute.cs
@@ -8,7 +8,7 @@ namespace BusinessApp.App
     /// </summary>
     public class ValidateObjectAttribute : ValidationAttribute
     {
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             if (value == null) return ValidationResult.Success;
 
@@ -23,8 +23,8 @@ namespace BusinessApp.App
             }
 
             return new CompositeValidationResult(
-                validationContext?.DisplayName,
-                string.Format("Validation for {0} failed!", validationContext?.DisplayName),
+                validationContext.DisplayName,
+                string.Format("Validation for {0} failed!", validationContext.DisplayName),
                 results);
         }
     }

--- a/CSharp/src/BusinessApp.App/ValidationRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.App/ValidationRequestDecorator.cs
@@ -10,6 +10,7 @@ namespace BusinessApp.App
     /// </summary>
     public class ValidationRequestDecorator<TRequest, TResult> :
         IRequestHandler<TRequest, TResult>
+        where TRequest : notnull
     {
         private readonly IValidator<TRequest> validator;
         private readonly IRequestHandler<TRequest, TResult> inner;

--- a/CSharp/src/BusinessApp.Data.IntegrationTest/EFEventStoreFactoryTests.cs
+++ b/CSharp/src/BusinessApp.Data.IntegrationTest/EFEventStoreFactoryTests.cs
@@ -199,21 +199,6 @@ namespace BusinessApp.Data.IntegrationTest
             }
 
             [Fact]
-            public void SetsEventMetadataCausationIdFromTriggerMetadataId()
-            {
-                /* Arrange */
-                EventMetadata<DomainEventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
-
-                /* Act */
-                var _ = store.Add(A.Dummy<DomainEventStub>());
-
-                /* Assert */
-                Assert.Same(triggerId, metadata.CausationId);
-            }
-
-            [Fact]
             public void SetsEventMetadataToTheEvent()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.Data.IntegrationTest/EFMetadataStoreRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Data.IntegrationTest/EFMetadataStoreRequestDecoratorTests.cs
@@ -120,20 +120,38 @@ namespace BusinessApp.Data.IntegrationTest
                 Assert.Same(id, metadata.Id);
             }
 
-            [Fact]
-            public void SetsMetadataUsernameProperty()
+            [Theory]
+            [InlineData("foouser", "foouser")]
+            [InlineData(null, "Anonymous")]
+            public void SetsMetadataUsernameProperty(string identityName, string setName)
             {
                 /* Arrange */
                 Metadata<RequestStub> metadata = null;
                 A.CallTo(() => db.Add(A<Metadata<RequestStub>>._))
                     .Invokes(ctx => metadata = ctx.GetArgument<Metadata<RequestStub>>(0));
-                A.CallTo(() => user.Identity.Name).Returns("foo");
+                A.CallTo(() => user.Identity.Name).Returns(identityName);
 
                 /* Act */
                 var _ = sut.HandleAsync(A.Dummy<RequestStub>(), cancelToken);
 
                 /* Assert */
-                Assert.Equal("foo", metadata.Username);
+                Assert.Equal(setName, metadata.Username);
+            }
+
+            [Fact]
+            public void NullIdentity_SetsAnonymousUsername()
+            {
+                /* Arrange */
+                Metadata<RequestStub> metadata = null;
+                A.CallTo(() => db.Add(A<Metadata<RequestStub>>._))
+                    .Invokes(ctx => metadata = ctx.GetArgument<Metadata<RequestStub>>(0));
+                A.CallTo(() => user.Identity).Returns(null);
+
+                /* Act */
+                var _ = sut.HandleAsync(A.Dummy<RequestStub>(), cancelToken);
+
+                /* Assert */
+                Assert.Equal(AnonymousUser.Name, metadata.Username);
             }
 
             [Fact]

--- a/CSharp/src/BusinessApp.Data.UnitTest/EventMetadataTests.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/EventMetadataTests.cs
@@ -31,6 +31,24 @@ namespace BusinessApp.Data.UnitTest
             }
 
             [Fact]
+            public void EventToStringNull_ExceptionThrown()
+            {
+                /* Arrange */
+                var i = A.Dummy<EventTrackingId>();
+                var e = A.Fake<DomainEventStub>();
+                A.CallTo(() => e.ToString()).Returns(null);
+                void shouldThrow() => new EventMetadata<DomainEventStub>(i, e);
+
+                /* Act */
+                var ex = Record.Exception(shouldThrow);
+
+                /* Assert */
+                Assert.IsType<BadStateException>(ex);
+                Assert.Equal("Event ToString must return a value: object cannot be null", ex.Message);
+            }
+
+
+            [Fact]
             public void EventArg_EventPropertySet()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.Data.UnitTest/EventMetadataTests.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/EventMetadataTests.cs
@@ -27,7 +27,7 @@ namespace BusinessApp.Data.UnitTest
                 var ex = Record.Exception(shouldThrow);
 
                 /* Assert */
-                Assert.NotNull(ex);
+                Assert.IsType<BadStateException>(ex);
             }
 
             [Fact]

--- a/CSharp/src/BusinessApp.Data.UnitTest/EventMetadataTests.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/EventMetadataTests.cs
@@ -47,7 +47,6 @@ namespace BusinessApp.Data.UnitTest
                 Assert.Equal("Event ToString must return a value: object cannot be null", ex.Message);
             }
 
-
             [Fact]
             public void EventArg_EventPropertySet()
             {

--- a/CSharp/src/BusinessApp.Data.UnitTest/MetadataTests.cs
+++ b/CSharp/src/BusinessApp.Data.UnitTest/MetadataTests.cs
@@ -50,7 +50,26 @@ namespace BusinessApp.Data.UnitTest
                 var ex = Record.Exception(shouldThrow);
 
                 /* Assert */
-                Assert.NotNull(ex);
+                Assert.IsType<BadStateException>(ex);
+            }
+
+            [Fact]
+            public void DataToString_WhenNull_ExceptionThrown()
+            {
+                /* Arrange */
+                var e = A.Fake<DomainEventStub>();
+                A.CallTo(() => e.ToString()).Returns(null);
+                void shouldThrow() => new Metadata<DomainEventStub>(A.Dummy<MetadataId>(),
+                    "foo", A.Dummy<MetadataType>(), e);
+
+                /* Act */
+                var ex = Record.Exception(shouldThrow);
+
+                /* Assert */
+                Assert.IsType<BadStateException>(ex);
+                Assert.Equal(
+                    "data ToString() must return a value for the DataSetName: object cannot be null",
+                    ex.Message);
             }
 
             [Fact]

--- a/CSharp/src/BusinessApp.Data/AndSpecificationBuilder.cs
+++ b/CSharp/src/BusinessApp.Data/AndSpecificationBuilder.cs
@@ -7,9 +7,9 @@
     /// <summary>
     /// Combines all specifications with the & operator
     /// </summary>
-    public class AndSpecificationBuilder<TQuery, TResult> :
-        IQueryVisitorFactory<TQuery, TResult>,
+    public class AndSpecificationBuilder<TQuery, TResult> : IQueryVisitorFactory<TQuery, TResult>,
         ILinqSpecificationBuilder<TQuery, TResult>
+        where TQuery : notnull
     {
         private readonly IEnumerable<ILinqSpecificationBuilder<TQuery, TResult>> builders;
 

--- a/CSharp/src/BusinessApp.Data/BusinessApp.Data.csproj
+++ b/CSharp/src/BusinessApp.Data/BusinessApp.Data.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BusinessApp.App\BusinessApp.App.csproj" />

--- a/CSharp/src/BusinessApp.Data/BusinessAppDataException.cs
+++ b/CSharp/src/BusinessApp.Data/BusinessAppDataException.cs
@@ -9,7 +9,7 @@ namespace BusinessApp.Data
     [Serializable]
     public class BusinessAppDataException : BusinessAppException
     {
-        public BusinessAppDataException(string message, Exception inner = null)
+        public BusinessAppDataException(string message, Exception? inner = null)
             :base(message, inner)
         { }
     }

--- a/CSharp/src/BusinessApp.Data/CompositeQueryVisitorBuilder.cs
+++ b/CSharp/src/BusinessApp.Data/CompositeQueryVisitorBuilder.cs
@@ -8,6 +8,7 @@
     /// Builds one factory from many query visitor factories
     /// </summary>
     public sealed class CompositeQueryVisitorBuilder<TQuery, TResult> : IQueryVisitorFactory<TQuery, TResult>
+        where TQuery : notnull
     {
         private readonly IEnumerable<IQueryVisitorFactory<TQuery, TResult>> factories;
 

--- a/CSharp/src/BusinessApp.Data/ConstructedQueryVisitorFactory.cs
+++ b/CSharp/src/BusinessApp.Data/ConstructedQueryVisitorFactory.cs
@@ -7,6 +7,7 @@ namespace BusinessApp.Data
     /// from the runtime <typeparam name="TQuery"/>
     /// </summary>
     public sealed class ConstructedQueryVisitorFactory<TQuery, TResult> : IQueryVisitorFactory<TQuery, TResult>
+        where TQuery : notnull
         where TResult : class
     {
         private readonly IQueryVisitor<TResult> visitor;

--- a/CSharp/src/BusinessApp.Data/EFEventStoreFactory.cs
+++ b/CSharp/src/BusinessApp.Data/EFEventStoreFactory.cs
@@ -1,6 +1,7 @@
 namespace BusinessApp.Data
 {
     using System.Security.Principal;
+    using BusinessApp.App;
     using BusinessApp.Domain;
 
     public class EFEventStoreFactory : IEventStoreFactory
@@ -20,7 +21,9 @@ namespace BusinessApp.Data
         public IEventStore Create<T>(T trigger) where T : class
         {
             var id = idFactory.Create();
-            var metadata = new Metadata<T>(id, user.Identity.Name, MetadataType.EventTrigger,
+            var metadata = new Metadata<T>(id,
+                user.Identity?.Name ?? AnonymousUser.Name,
+                MetadataType.EventTrigger,
                 trigger);
 
             db.Add(metadata);
@@ -42,7 +45,7 @@ namespace BusinessApp.Data
                 this.correlationId = correlationId;
             }
 
-            public EventTrackingId Add<T>(T @event) where T : IDomainEvent
+            public EventTrackingId Add<T>(T @event) where T : notnull, IDomainEvent
             {
                 var eventId =  idFactory.Create();
                 var id = new EventTrackingId(eventId, correlationId)

--- a/CSharp/src/BusinessApp.Data/EFEventStoreFactory.cs
+++ b/CSharp/src/BusinessApp.Data/EFEventStoreFactory.cs
@@ -48,10 +48,7 @@ namespace BusinessApp.Data
             public EventTrackingId Add<T>(T @event) where T : notnull, IDomainEvent
             {
                 var eventId =  idFactory.Create();
-                var id = new EventTrackingId(eventId, correlationId)
-                {
-                    CausationId = correlationId
-                };
+                var id = new EventTrackingId(eventId, correlationId);
 
                 var metadata =  new EventMetadata<T>(id, @event);
 

--- a/CSharp/src/BusinessApp.Data/EFMetadataStoreRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.Data/EFMetadataStoreRequestDecorator.cs
@@ -32,7 +32,10 @@ namespace BusinessApp.Data
             CancellationToken cancelToken)
         {
             var eventId = idFactory.Create();
-            var metadata = new Metadata<TRequest>(eventId, user.Identity.Name, MetadataType.Request, request);
+            var metadata = new Metadata<TRequest>(eventId,
+                user.Identity?.Name ?? AnonymousUser.Name,
+                MetadataType.Request,
+                request);
 
             db.Add(metadata);
 

--- a/CSharp/src/BusinessApp.Data/EFQueryFieldsVisitor.cs
+++ b/CSharp/src/BusinessApp.Data/EFQueryFieldsVisitor.cs
@@ -52,7 +52,7 @@
 
         private static IQueryable<TResult> QueryFields(IQueryable<TResult> query, IEnumerable<string> fields)
         {
-            if (ExpressionCache.TryGetValue(fields, out Expression<Func<TResult, TResult>> selector))
+            if (ExpressionCache.TryGetValue(fields, out Expression<Func<TResult, TResult>>? selector))
             {
                 return query.Select(selector);
             }

--- a/CSharp/src/BusinessApp.Data/EFQuerySortVisitor.cs
+++ b/CSharp/src/BusinessApp.Data/EFQuerySortVisitor.cs
@@ -58,7 +58,7 @@ namespace BusinessApp.Data
 
         private static Expression<Func<TResult, object>> CreateSortExpression(string fieldName)
         {
-            if (ExpressionCache.TryGetValue(fieldName, out Expression<Func<TResult, object>> selector))
+            if (ExpressionCache.TryGetValue(fieldName, out Expression<Func<TResult, object>>? selector))
             {
                 return selector;
             }

--- a/CSharp/src/BusinessApp.Data/EFQueryStrategyHandler.cs
+++ b/CSharp/src/BusinessApp.Data/EFQueryStrategyHandler.cs
@@ -12,7 +12,7 @@
     /// Entity Framework query handler for many record sets
     /// </summary>
     public class EFQueryStrategyHandler<TQuery, TResult> : IRequestHandler<TQuery, IEnumerable<TResult>>
-        where TQuery : IQuery
+        where TQuery : notnull, IQuery
         where TResult : class
     {
         private readonly BusinessAppDbContext db;

--- a/CSharp/src/BusinessApp.Data/EFQueryVisitorFactory.cs
+++ b/CSharp/src/BusinessApp.Data/EFQueryVisitorFactory.cs
@@ -6,7 +6,7 @@ namespace BusinessApp.Data
     /// Factory to create an Entity Framework query visitor
     /// </summary>
     public class EFQueryVisitorFactory<TQuery, TResult> : IQueryVisitorFactory<TQuery, TResult>
-        where TQuery : IQuery
+        where TQuery : notnull, IQuery
         where TResult : class
     {
         public IQueryVisitor<TResult> Create(TQuery query) =>

--- a/CSharp/src/BusinessApp.Data/EFTrackingQueryDecorator.cs
+++ b/CSharp/src/BusinessApp.Data/EFTrackingQueryDecorator.cs
@@ -13,7 +13,7 @@ namespace BusinessApp.Data
     /// we are not worried about saving any entities during this transaction
     /// </summary>
     public class EFTrackingQueryDecorator<TQuery, TResult> : IRequestHandler<TQuery, TResult>
-        where TQuery : IQuery
+        where TQuery : notnull, IQuery
     {
         private readonly IRequestHandler<TQuery, TResult> inner;
 

--- a/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Data/EFUnitOfWork.cs
@@ -93,9 +93,9 @@ namespace BusinessApp.Data
             return this;
         }
 
-        public TRoot Find<TRoot>(Func<TRoot, bool> filter) where TRoot : AggregateRoot
+        public T? Find<T>(Func<T, bool> filter) where T : AggregateRoot
         {
-            return db.ChangeTracker.Entries<TRoot>()
+            return db.ChangeTracker.Entries<T>()
                 .Select(e => e.Entity)
                 .SingleOrDefault(filter);
         }

--- a/CSharp/src/BusinessApp.Data/EventMetadata.cs
+++ b/CSharp/src/BusinessApp.Data/EventMetadata.cs
@@ -17,7 +17,9 @@ namespace BusinessApp.Data
             Id = id.Id;
             CorrelationId = id.CorrelationId;
             CausationId = id.CausationId;
-            EventName = e.NotNull().Expect(nameof(e)).ToString()!;
+            EventName = e.NotNull().Expect(nameof(e))
+                .ToString()
+                .Expect("Event ToString must return a value");
             OccurredUtc = e.OccurredUtc;
         }
 

--- a/CSharp/src/BusinessApp.Data/EventMetadata.cs
+++ b/CSharp/src/BusinessApp.Data/EventMetadata.cs
@@ -5,8 +5,10 @@ namespace BusinessApp.Data
 
     public abstract class EventMetadata
     {
+#nullable disable
         protected EventMetadata()
         {}
+#nullable restore
 
         public EventMetadata(EventTrackingId id, IDomainEvent e)
         {
@@ -15,7 +17,7 @@ namespace BusinessApp.Data
             Id = id.Id;
             CorrelationId = id.CorrelationId;
             CausationId = id.CausationId;
-            EventName = e.ToString();
+            EventName = e.NotNull().Expect(nameof(e)).ToString()!;
             OccurredUtc = e.OccurredUtc;
         }
 
@@ -30,10 +32,12 @@ namespace BusinessApp.Data
     /// Model to store event metadata.
     /// </summary>
     public class EventMetadata<T> : EventMetadata
-        where T : IDomainEvent
+        where T : notnull, IDomainEvent
     {
+#nullable disable
         private EventMetadata()
         {}
+#nullable restore
 
         public EventMetadata(EventTrackingId id, T e)
             : base(id, e)

--- a/CSharp/src/BusinessApp.Data/IDbSetVisitorFactory.cs
+++ b/CSharp/src/BusinessApp.Data/IDbSetVisitorFactory.cs
@@ -1,6 +1,7 @@
 namespace BusinessApp.Data
 {
     public interface IDbSetVisitorFactory<in TQuery, TResult>
+        where TQuery : notnull
         where TResult : class
     {
         IDbSetVisitor<TResult> Create(TQuery query);

--- a/CSharp/src/BusinessApp.Data/ILinqSpecificationBuilder.cs
+++ b/CSharp/src/BusinessApp.Data/ILinqSpecificationBuilder.cs
@@ -6,6 +6,7 @@ namespace BusinessApp.Data
     /// Interface to build a <see cref="LinqSpecification{}"/> from the query
     /// </summary>
     public interface ILinqSpecificationBuilder<in TQuery, TResult>
+        where TQuery : notnull
     {
         LinqSpecification<TResult> Build(TQuery query);
     }

--- a/CSharp/src/BusinessApp.Data/IQueryVisitorFactory.cs
+++ b/CSharp/src/BusinessApp.Data/IQueryVisitorFactory.cs
@@ -4,6 +4,7 @@
     /// Create  a query visitor from the query at runtime
     /// </summary>
     public interface IQueryVisitorFactory<in TQuery, TResult>
+        where TQuery : notnull
     {
         IQueryVisitor<TResult> Create(TQuery query);
     }

--- a/CSharp/src/BusinessApp.Data/Metadata.cs
+++ b/CSharp/src/BusinessApp.Data/Metadata.cs
@@ -5,8 +5,10 @@ namespace BusinessApp.Data
 
     public class Metadata
     {
+#nullable disable
         protected Metadata()
         {}
+#nullable restore
 
         public Metadata(string dataSetName, MetadataId id, string username, MetadataType type)
         {
@@ -27,13 +29,15 @@ namespace BusinessApp.Data
     public class Metadata<T> : Metadata
         where T : class
     {
+#nullable disable
         private Metadata()
         {}
+#nullable restore
 
         public Metadata(MetadataId id, string username, MetadataType type, T data)
-            :base (data?.ToString(), id, username, type)
+            :base (data?.ToString()!, id, username, type)
         {
-            Data = data.NotDefault().Expect(nameof(data));
+            Data = data.NotDefault().Expect(nameof(data))!;
         }
 
         public T Data { get; }

--- a/CSharp/src/BusinessApp.Data/Metadata.cs
+++ b/CSharp/src/BusinessApp.Data/Metadata.cs
@@ -35,7 +35,8 @@ namespace BusinessApp.Data
 #nullable restore
 
         public Metadata(MetadataId id, string username, MetadataType type, T data)
-            :base (data?.ToString()!, id, username, type)
+            // TODO left off ==> test this
+            :base (data.Expect(nameof(data)).ToString().Expect("data ToString() must return a value for the DataSetName"), id, username, type)
         {
             Data = data.NotDefault().Expect(nameof(data))!;
         }

--- a/CSharp/src/BusinessApp.Data/Metadata.cs
+++ b/CSharp/src/BusinessApp.Data/Metadata.cs
@@ -41,7 +41,7 @@ namespace BusinessApp.Data
                     .Expect("data ToString() must return a value for the DataSetName"),
                 id, username, type)
         {
-            Data = data.NotDefault().Expect(nameof(data))!;
+            Data = data.NotDefault().Expect(nameof(data));
         }
 
         public T Data { get; }

--- a/CSharp/src/BusinessApp.Data/Metadata.cs
+++ b/CSharp/src/BusinessApp.Data/Metadata.cs
@@ -35,8 +35,11 @@ namespace BusinessApp.Data
 #nullable restore
 
         public Metadata(MetadataId id, string username, MetadataType type, T data)
-            // TODO left off ==> test this
-            :base (data.Expect(nameof(data)).ToString().Expect("data ToString() must return a value for the DataSetName"), id, username, type)
+            :base (
+                data.Expect(nameof(data))
+                    .ToString()
+                    .Expect("data ToString() must return a value for the DataSetName"),
+                id, username, type)
         {
             Data = data.NotDefault().Expect(nameof(data))!;
         }

--- a/CSharp/src/BusinessApp.Data/NullDbSetVisitorFactory.cs
+++ b/CSharp/src/BusinessApp.Data/NullDbSetVisitorFactory.cs
@@ -1,6 +1,7 @@
 namespace BusinessApp.Data
 {
     public sealed class NullDbSetVisitorFactory<TQuery, TResult> : IDbSetVisitorFactory<TQuery, TResult>
+        where TQuery : notnull
         where TResult : class
     {
         private static readonly NullDbSetVisitor<TResult> Visitor = new NullDbSetVisitor<TResult>();

--- a/CSharp/src/BusinessApp.Data/QueryOperatorSpecificationBuilder.cs
+++ b/CSharp/src/BusinessApp.Data/QueryOperatorSpecificationBuilder.cs
@@ -32,10 +32,11 @@ namespace BusinessApp.Data
         {
             if (DescriptorCache.TryGetValue(query.GetType(), out ICollection<SpecificationDescriptor>? e))
             {
-                var spec = e.Select(p => CreateSpec(query, p))
-                    .Where(s => s != null);
+                IEnumerable<LinqSpecification<TContract>> spec = e
+                    .Select(p => CreateSpec(query, p))
+                    .Where(s => s != null)!;
 
-                return spec.Any() ? spec.Aggregate((a, b) => a! & b!)! : new NullSpecification<TContract>(true);
+                return spec.Any() ? spec.Aggregate((a, b) => a & b) : new NullSpecification<TContract>(true);
             }
 
             DescriptorCache[query.GetType()] = new List<SpecificationDescriptor>();

--- a/CSharp/src/BusinessApp.Data/QueryOperatorSpecificationBuilder.cs
+++ b/CSharp/src/BusinessApp.Data/QueryOperatorSpecificationBuilder.cs
@@ -11,6 +11,7 @@ namespace BusinessApp.Data
 
     public class QueryOperatorSpecificationBuilder<TQuery, TContract> :
         ILinqSpecificationBuilder<TQuery, TContract>
+        where TQuery : notnull
     {
         private static ConcurrentDictionary<Type, ICollection<SpecificationDescriptor>> DescriptorCache
             = new ConcurrentDictionary<Type, ICollection<SpecificationDescriptor>>();
@@ -29,12 +30,12 @@ namespace BusinessApp.Data
 
         public LinqSpecification<TContract> Build(TQuery query)
         {
-            if (DescriptorCache.TryGetValue(query.GetType(), out ICollection<SpecificationDescriptor> e))
+            if (DescriptorCache.TryGetValue(query.GetType(), out ICollection<SpecificationDescriptor>? e))
             {
                 var spec = e.Select(p => CreateSpec(query, p))
                     .Where(s => s != null);
 
-                return spec.Any() ? spec.Aggregate((a, b) => a & b) : new NullSpecification<TContract>(true);
+                return spec.Any() ? spec.Aggregate((a, b) => a! & b!)! : new NullSpecification<TContract>(true);
             }
 
             DescriptorCache[query.GetType()] = new List<SpecificationDescriptor>();
@@ -43,7 +44,7 @@ namespace BusinessApp.Data
             return Build(query);
         }
 
-        private static LinqSpecification<TContract> CreateSpec(TQuery query,
+        private static LinqSpecification<TContract>? CreateSpec(TQuery query,
             SpecificationDescriptor e)
         {
             var propertyValue = e.PropertyGetter(query);
@@ -66,10 +67,10 @@ namespace BusinessApp.Data
 
             void FillCache(PropertyInfo property, Expression queryExp, Expression contractExp)
             {
-                var attribute = property.GetCustomAttribute<QueryOperatorAttribute>();
+                var attribute = property.GetCustomAttribute<QueryOperatorAttribute>()!;
 
                 var queryProp = Expression.Property(
-                    Expression.Convert(queryExp, property.DeclaringType), property);
+                    Expression.Convert(queryExp, property.DeclaringType!), property);
 
                 if (attribute.OperatorToUse == null && !seenTypes.Contains(property.PropertyType))
                 {
@@ -95,9 +96,7 @@ namespace BusinessApp.Data
                 {
                     var contractProp = Expression.Property(contractExp, opAttr.TargetProp);
 
-                    DescriptorCache[queryType].Add(new SpecificationDescriptor
-                    {
-                        PropertyGetter =
+                    DescriptorCache[queryType].Add(new SpecificationDescriptor(
                            Expression.Lambda<Func<TQuery, object>>(
                                Expression.Condition(
                                    Expression.ReferenceEqual(queryExp, Expression.Constant(null)),
@@ -105,15 +104,15 @@ namespace BusinessApp.Data
                                    Expression.Convert(queryProp, typeof(object))
                                ), QueryParam
                            ).Compile(),
-                        ContractProp = contractProp,
-                        Attribute = opAttr
-                    });
+                        contractProp,
+                        opAttr
+                    ));
                 }
             };
 
             var props = queryType
                 .GetProperties()
-                .Where(p => p.IsDefined(typeof(QueryOperatorAttribute)));
+                .Where(p => p.DeclaringType != null && p.IsDefined(typeof(QueryOperatorAttribute)));
 
             foreach (var p in props) FillCache(p, QueryParam, ContractParam);
         }
@@ -123,20 +122,19 @@ namespace BusinessApp.Data
             Expression queryMemberExpr,
             MemberExpression contractMemberExpr)
         {
-            var contractP = contractMemberExpr.Member as PropertyInfo;
+            var contractProp = contractMemberExpr.Member as PropertyInfo;
             var needToConvert =
-                (Nullable.GetUnderlyingType(contractP.PropertyType) != null
+                (Nullable.GetUnderlyingType(contractProp!.PropertyType) != null
                 && attribute.OperatorToUse != QueryOperators.Contains);
             var queryExp = needToConvert switch
             {
                 false => (Expression)queryMemberExpr,
-                true => (Expression)Expression.Convert(queryMemberExpr, contractP.PropertyType),
+                true => (Expression)Expression.Convert(queryMemberExpr, contractProp.PropertyType),
             };
 
             switch (attribute.OperatorToUse)
             {
                 case QueryOperators.Contains:
-                    var contractProp = contractMemberExpr.Member as PropertyInfo;
                     var method = typeof(Enumerable)
                         .GetMethods(BindingFlags.Static | BindingFlags.Public)
                         .Where(x => x.Name == "Contains")
@@ -172,9 +170,18 @@ namespace BusinessApp.Data
 
         private sealed class SpecificationDescriptor
         {
-            public Func<TQuery, object> PropertyGetter { get; set; }
-            public MemberExpression ContractProp { get; set; }
-            public QueryOperatorAttribute Attribute { get; set; }
+            public SpecificationDescriptor(Func<TQuery, object> propertyGetter,
+                MemberExpression contractProp,
+                QueryOperatorAttribute attribute)
+            {
+                PropertyGetter = propertyGetter;
+                ContractProp = contractProp;
+                Attribute = attribute;
+            }
+
+            public Func<TQuery, object> PropertyGetter { get; }
+            public MemberExpression ContractProp { get; }
+            public QueryOperatorAttribute Attribute { get; }
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain.UnitTest/EntityIdTypeConverterTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EntityIdTypeConverterTests.cs
@@ -176,51 +176,6 @@ namespace BusinessApp.Domain.UnitTest
             }
         }
 
-        public class IsValid : EntityIdTypeConverterTests
-        {
-            [Fact]
-            public void WithoutInnerValueConstructor_FalseReturned()
-            {
-                /* Arrange */
-                var sut = new EntityIdTypeConverter<BadEntityIdStub, int>();
-                int val = 1;
-
-                /* Act */
-                var isValid = sut.IsValid(null, val);
-
-                /* Assert */
-                Assert.False(isValid);
-            }
-
-            [Fact]
-            public void EqualSourceType_TrueReturned()
-            {
-                /* Arrange */
-                var sut = new EntityIdTypeConverter<EntityIdStub, int>();
-                int val = 1;
-
-                /* Act */
-                var isValid = sut.IsValid(null, val);
-
-                /* Assert */
-                Assert.True(isValid);
-            }
-
-            [Fact]
-            public void DifferentType_WhenInnerConverterCanConvert_TrueReturned()
-            {
-                /* Arrange */
-                var sut = new EntityIdTypeConverter<EntityIdStub, int>();
-                string val = "+123";
-
-                /* Act */
-                var isValid = sut.IsValid(null, val);
-
-                /* Assert */
-                Assert.True(isValid);
-            }
-        }
-
         public struct EntityIdStub : IEntityId
         {
             public EntityIdStub(int id)

--- a/CSharp/src/BusinessApp.Domain.UnitTest/EventStreamTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EventStreamTests.cs
@@ -60,6 +60,26 @@ namespace BusinessApp.Domain.UnitTest
                 /* Assert */
                 Assert.Equal(4, stream.Count());
             }
+
+            [Fact]
+            public void CurrentIsNull_Throws()
+            {
+                /* Arrange */
+                var events = A.CollectionOfDummy<IDomainEvent>(2);
+                var stream = new EventStream(events);
+                var _ = stream.Select(s => s).ToList();
+                var enumerator = stream.GetEnumerator();
+                enumerator.MoveNext();
+                enumerator.MoveNext();
+                enumerator.MoveNext();
+
+                /* Act */
+                var ex = Record.Exception(() => enumerator.Current);
+
+                /* Assert */
+                Assert.IsType<BadStateException>(ex);
+                Assert.Equal("Object cannot be access because it is null", ex.Message);
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain.UnitTest/EventTrackingIdTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EventTrackingIdTests.cs
@@ -52,6 +52,19 @@ namespace BusinessApp.Domain.UnitTest
                 /* Assert */
                 Assert.Equal(correlationId, sut.CorrelationId);
             }
+
+            [Fact]
+            public void SetsCausationIdFromCorrelationIdProperty()
+            {
+                /* Arrange */
+                var correlationId = (MetadataId)1;
+
+                /* Act */
+                var sut = new EventTrackingId(A.Dummy<MetadataId>(), correlationId);
+
+                /* Assert */
+                Assert.Equal(correlationId, sut.CausationId);
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain.UnitTest/EventTrackingIdTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/EventTrackingIdTests.cs
@@ -65,6 +65,20 @@ namespace BusinessApp.Domain.UnitTest
                 /* Assert */
                 Assert.Equal(correlationId, sut.CausationId);
             }
+
+            [Fact]
+            public void TrySetNullCausationId_Throws()
+            {
+                /* Arrange */
+                var sut = new EventTrackingId(A.Dummy<MetadataId>(), A.Dummy<MetadataId>());
+
+                /* Act */
+                 var ex = Record.Exception(() => sut.CausationId = null);
+
+                /* Assert */
+                Assert.IsType<BadStateException>(ex);
+                Assert.Equal("CausationId: Value cannot be null", ex.Message);
+            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain.UnitTest/ResultTests.cs
+++ b/CSharp/src/BusinessApp.Domain.UnitTest/ResultTests.cs
@@ -113,6 +113,19 @@ namespace BusinessApp.Domain.UnitTest
         public class ErrorFactory : ResultOfTETests
         {
             [Fact]
+            public void NullError_Throws()
+            {
+                /* Arrange */
+                string error = null;
+
+                /* Act */
+                var ex = Record.Exception(() => Result<_, string>.Error(error));
+
+                /* Assert */
+                Assert.NotNull(ex);
+            }
+
+            [Fact]
             public void KindProperty_IsError()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.Domain/BadStateException.cs
+++ b/CSharp/src/BusinessApp.Domain/BadStateException.cs
@@ -8,11 +8,7 @@
     [Serializable]
     public class BadStateException : Exception
     {
-        public BadStateException(string message)
-            : this(message, null)
-        { }
-
-        public BadStateException(string message, Exception innerException)
+        public BadStateException(string message, Exception? innerException = null)
             : base(message, innerException)
         {
             Data[""] = message;

--- a/CSharp/src/BusinessApp.Domain/BusinessApp.Domain.csproj
+++ b/CSharp/src/BusinessApp.Domain/BusinessApp.Domain.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/CSharp/src/BusinessApp.Domain/BusinessAppException.cs
+++ b/CSharp/src/BusinessApp.Domain/BusinessAppException.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.Domain
     [Serializable]
     public class BusinessAppException : Exception
     {
-        public BusinessAppException(string message, Exception inner = null)
+        public BusinessAppException(string message, Exception? inner = null)
             :base(message, inner)
         { }
     }

--- a/CSharp/src/BusinessApp.Domain/EntityIdTypeConveter.cs
+++ b/CSharp/src/BusinessApp.Domain/EntityIdTypeConveter.cs
@@ -14,7 +14,7 @@
         private static readonly Type InnerType = typeof(T);
         private static readonly Type IdType = typeof(TId);
         private static readonly TypeConverter Inner;
-        private static readonly ConstructorInfo ConvertFromCtor;
+        private static readonly ConstructorInfo? ConvertFromCtor;
 
         static EntityIdTypeConverter()
         {
@@ -66,20 +66,6 @@
             if (InnerType == destinationType) return innerValue;
 
             return Inner.ConvertTo(context, culture, innerValue, destinationType);
-        }
-
-        public override bool IsValid(ITypeDescriptorContext context, object value)
-        {
-            try
-            {
-                var valueType = value?.GetType();
-
-                return CanConvertFrom(context, valueType);
-            }
-            catch
-            {
-                return false;
-            }
         }
     }
 }

--- a/CSharp/src/BusinessApp.Domain/EventStream.cs
+++ b/CSharp/src/BusinessApp.Domain/EventStream.cs
@@ -31,7 +31,7 @@ namespace BusinessApp.Domain
         {
             private readonly Queue<IDomainEvent> enumeratored;
             private Queue<IDomainEvent> queue;
-            private IDomainEvent currentEvent;
+            private IDomainEvent? currentEvent;
 
             public EventEnumerator(Queue<IDomainEvent> queue)
             {
@@ -45,7 +45,7 @@ namespace BusinessApp.Domain
                 {
                     lock (queue)
                     {
-                        return currentEvent;
+                        return currentEvent.Unwrap();
                     }
                 }
             }

--- a/CSharp/src/BusinessApp.Domain/EventTrackingId.cs
+++ b/CSharp/src/BusinessApp.Domain/EventTrackingId.cs
@@ -5,10 +5,13 @@ namespace BusinessApp.Domain
     /// </summary>
     public class EventTrackingId
     {
+        private MetadataId causationId;
+
         public EventTrackingId(MetadataId id, MetadataId correlationId)
         {
             Id = id.NotNull().Expect(nameof(id));
             CorrelationId = correlationId.NotNull().Expect(nameof(correlationId));
+            causationId = correlationId;
         }
 
         /// <summary>
@@ -28,6 +31,10 @@ namespace BusinessApp.Domain
         /// <summary>
         /// The id of the object that triggered the event
         /// </summary>
-        public MetadataId CausationId { get; set; }
+        public MetadataId CausationId
+        {
+            get => causationId;
+            set => causationId = value.NotNull().Expect(nameof(CausationId));
+        }
     }
 }

--- a/CSharp/src/BusinessApp.Domain/IEntityId.cs
+++ b/CSharp/src/BusinessApp.Domain/IEntityId.cs
@@ -7,82 +7,82 @@
     /// </summary>
     public interface IEntityId : IConvertible
     {
-        bool IConvertible.ToBoolean(IFormatProvider provider)
+        bool IConvertible.ToBoolean(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        byte IConvertible.ToByte(IFormatProvider provider)
+        byte IConvertible.ToByte(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        char IConvertible.ToChar(IFormatProvider provider)
+        char IConvertible.ToChar(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        DateTime IConvertible.ToDateTime(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        decimal IConvertible.ToDecimal(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        double IConvertible.ToDouble(IFormatProvider provider)
+        double IConvertible.ToDouble(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        short IConvertible.ToInt16(IFormatProvider provider)
+        short IConvertible.ToInt16(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        int IConvertible.ToInt32(IFormatProvider provider)
+        int IConvertible.ToInt32(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        long IConvertible.ToInt64(IFormatProvider provider)
+        long IConvertible.ToInt64(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        sbyte IConvertible.ToSByte(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        float IConvertible.ToSingle(IFormatProvider provider)
+        float IConvertible.ToSingle(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        string IConvertible.ToString(IFormatProvider provider)
+        string IConvertible.ToString(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        object IConvertible.ToType(Type conversionType, IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        ushort IConvertible.ToUInt16(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        uint IConvertible.ToUInt32(IFormatProvider provider)
+        uint IConvertible.ToUInt32(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }
 
-        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        ulong IConvertible.ToUInt64(IFormatProvider? provider)
         {
             throw new InvalidCastException();
         }

--- a/CSharp/src/BusinessApp.Domain/IEventHandler.cs
+++ b/CSharp/src/BusinessApp.Domain/IEventHandler.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.Domain
     /// <summary>
     /// Interface to handle event logic
     /// </summary>
-    public interface IEventHandler<TEvent> where TEvent : IDomainEvent
+    public interface IEventHandler<TEvent> where TEvent : notnull, IDomainEvent
     {
         Task<HandlerResult> HandleAsync(TEvent @event, CancellationToken cancelToken);
     }

--- a/CSharp/src/BusinessApp.Domain/IEventPublisher.cs
+++ b/CSharp/src/BusinessApp.Domain/IEventPublisher.cs
@@ -13,6 +13,6 @@ namespace BusinessApp.Domain
     public interface IEventPublisher
     {
         Task<EventsResult> PublishAsync<T>(T @event, CancellationToken cancelToken)
-            where T : IDomainEvent;
+            where T : notnull, IDomainEvent;
     }
 }

--- a/CSharp/src/BusinessApp.Domain/IEventStore.cs
+++ b/CSharp/src/BusinessApp.Domain/IEventStore.cs
@@ -8,6 +8,6 @@ namespace BusinessApp.Domain
         /// <summary>
         /// Adds an event to the store
         /// </summary>
-        EventTrackingId Add<T>(T @event) where T : IDomainEvent;
+        EventTrackingId Add<T>(T @event) where T : notnull, IDomainEvent;
     }
 }

--- a/CSharp/src/BusinessApp.Domain/IUnitOfWork.cs
+++ b/CSharp/src/BusinessApp.Domain/IUnitOfWork.cs
@@ -11,7 +11,7 @@
     {
         event EventHandler Committing;
         event EventHandler Committed;
-        T Find<T>(Func<T, bool> filter) where T : AggregateRoot;
+        T? Find<T>(Func<T, bool> filter) where T : AggregateRoot;
         void Add<T>(T aggregate) where T : AggregateRoot;
         void Remove<T>(T aggregate) where T : AggregateRoot;
         void Track<T>(T aggregate) where T : AggregateRoot;

--- a/CSharp/src/BusinessApp.Domain/LinqSpecification.cs
+++ b/CSharp/src/BusinessApp.Domain/LinqSpecification.cs
@@ -45,9 +45,11 @@ namespace BusinessApp.Domain
                 this.to = to;
             }
 
-            public override Expression Visit(Expression node)
+            public override Expression Visit(Expression? node)
             {
-                return node == from ? to : base.Visit(node);
+                // XXX node cannot be null because this is private class and we
+                // know what we are passing
+                return node == from ? to : base.Visit(node)!;
             }
         }
     }

--- a/CSharp/src/BusinessApp.Domain/LogEntry.cs
+++ b/CSharp/src/BusinessApp.Domain/LogEntry.cs
@@ -9,26 +9,27 @@
     /// </summary>
     public class LogEntry
     {
-        public LogEntry(LogSeverity severity,
-            string message,
-            Exception e = null,
-            object data = null)
+        public LogEntry(LogSeverity severity, string message)
         {
             Severity = severity;
-            Message = message;
-            Exception = e;
-            Data = data;
+            Message = message.NotEmpty().Expect("A log entry must have a message");
         }
 
         public static LogEntry FromException(Exception e)
         {
-            return new LogEntry(LogSeverity.Error, e?.Message, e, e.Data);
+            e.NotNull().Expect("Logging from an exception cannot be null");
+
+            return new LogEntry(LogSeverity.Error, e.Message)
+            {
+                Exception = e,
+                Data = e.Data
+            };
         }
 
-        public LogSeverity Severity { get; }
-        public string Message { get; }
-        public object Data { get; }
-        public Exception Exception { get; }
+        public LogSeverity Severity { get; init; }
+        public string Message { get; init; }
+        public object? Data { get; init; }
+        public Exception? Exception { get; init; }
         public DateTimeOffset Logged { get; } = DateTimeOffset.UtcNow;
 
         public override string ToString()

--- a/CSharp/src/BusinessApp.Domain/MetadataId.cs
+++ b/CSharp/src/BusinessApp.Domain/MetadataId.cs
@@ -17,7 +17,7 @@ namespace BusinessApp.Domain
 
         TypeCode IConvertible.GetTypeCode() => Id.GetTypeCode();
 
-        long IConvertible.ToInt64(IFormatProvider provider) => Id;
+        long IConvertible.ToInt64(IFormatProvider? provider) => Id;
 
         public static explicit operator long (MetadataId id) => id.Id;
 

--- a/CSharp/src/BusinessApp.Domain/NullableExtensions.cs
+++ b/CSharp/src/BusinessApp.Domain/NullableExtensions.cs
@@ -12,5 +12,10 @@ namespace BusinessApp.Domain
         {
             return obj ?? throw new BadStateException("Object cannot be access because it is null");
         }
+
+        public static T Expect<T>(this T? obj, string message)
+        {
+            return obj ?? throw new BadStateException($"{message}: object cannot be null");
+        }
     }
 }

--- a/CSharp/src/BusinessApp.Domain/NullableExtensions.cs
+++ b/CSharp/src/BusinessApp.Domain/NullableExtensions.cs
@@ -1,0 +1,16 @@
+namespace BusinessApp.Domain
+{
+    /// <summary>
+    /// Functional extensions to handle null references
+    /// </summary>
+    public static class NullableExtensions
+    {
+        /// <summary>
+        /// Returns the underlying object or throws if null
+        /// </summary>
+        public static T Unwrap<T>(this T? obj)
+        {
+            return obj ?? throw new BadStateException("Object cannot be access because it is null");
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.Domain/ResultFactories.cs
+++ b/CSharp/src/BusinessApp.Domain/ResultFactories.cs
@@ -36,7 +36,8 @@
 
         public static Result<T, string> NotDefault<T>(this T value)
         {
-            T defaultVal = default;
+            T? defaultVal = default;
+
             if (EqualityComparer<T>.Default.Equals(value, defaultVal))
             {
                 // null ToString = "";

--- a/CSharp/src/BusinessApp.Domain/Unit.cs
+++ b/CSharp/src/BusinessApp.Domain/Unit.cs
@@ -10,9 +10,9 @@ namespace BusinessApp.Domain
         public static Unit New => default;
 
         public int CompareTo(Unit other) => 0;
-        public int CompareTo(object obj) => 0;
+        public int CompareTo(object? obj) => 0;
         public bool Equals(Unit other) => true;
-        public override bool Equals(object obj) => obj is Unit;
+        public override bool Equals(object? obj) => obj is Unit;
         public override int GetHashCode() => 0;
         public override string ToString() => "()";
         public static bool operator ==(Unit first, Unit second) => true;

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/HateoasLinkTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/HateoasLinkTests.cs
@@ -14,7 +14,7 @@ namespace BusinessApp.WebApi.UnitTest
             {
                 get
                 {
-                    return new []
+                    return new[]
                     {
                         new object[]
                         {
@@ -48,6 +48,22 @@ namespace BusinessApp.WebApi.UnitTest
                 /* Assert */
                 Assert.IsType<BadStateException>(exception);
             }
+
+            [Fact]
+            public void RelArgOnlyInChildClass_SetsRelLink()
+            {
+                /* Act */
+                var child = new ChildHateoasLinkStub("foo");
+
+                /* Assert */
+                Assert.Equal("foo", child.RelativeLinkFactory(1, 2));
+            }
+        }
+
+        private sealed class ChildHateoasLinkStub : HateoasLink<int, int>
+        {
+            public ChildHateoasLinkStub(string rel) : base(rel)
+            { }
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/LocalizedProblemDetailFactoryTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/LocalizedProblemDetailFactoryTests.cs
@@ -47,6 +47,62 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
         public class Create : LocalizedProblemDetailFactoryTests
         {
             [Fact]
+            public void NoDetailProp_TranslationCalled()
+            {
+                /* Arrange */
+                var exception = A.Dummy<Exception>();
+                var problem = new ProblemDetail(400);
+                A.CallTo(() => inner.Create(exception)).Returns(problem);
+
+                /* Act */
+                var localizedProblem = sut.Create(exception);
+
+                /* Assert */
+                A.CallTo(() => localizer[A<string>._]).MustNotHaveHappened();
+                Assert.Null(localizedProblem.Detail);
+            }
+
+            [Fact]
+            public void DetailProp_TranslationCalled()
+            {
+                /* Arrange */
+                var exception = A.Dummy<Exception>();
+                var localizedStr = new LocalizedString("bar", "ipsum");
+                var problem = new ProblemDetail(400)
+                {
+                    Detail = "foobar"
+
+                };
+                A.CallTo(() => localizer["foobar"]).Returns(localizedStr);
+                A.CallTo(() => inner.Create(exception)).Returns(problem);
+
+                /* Act */
+                var localizedProblem = sut.Create(exception);
+
+                /* Assert */
+                Assert.Equal("ipsum", localizedProblem.Detail);
+            }
+
+            [Fact]
+            public void NullExtensionValue_AddedAsEmptyString()
+            {
+                /* Arrange */
+                var exception = A.Dummy<Exception>();
+                var localizedStr = new LocalizedString("bar", "ipsum");
+                var problem = new ProblemDetail(400)
+                {
+                    { "foo", null }
+                };
+                A.CallTo(() => inner.Create(exception)).Returns(problem);
+
+                /* Act */
+                var localizedProblem = sut.Create(exception);
+
+                /* Assert */
+                Assert.Equal("", localizedProblem["foo"]);
+            }
+
+            [Fact]
             public void StringExtension_TranslationCalled()
             {
                 /* Arrange */

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/LocalizedProblemDetailFactoryTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/LocalizedProblemDetailFactoryTests.cs
@@ -103,6 +103,27 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
             }
 
             [Fact]
+            public void NullExtensionToStringValue_AddedAsEmptyString()
+            {
+                /* Arrange */
+                var exception = A.Dummy<Exception>();
+                var localizedStr = new LocalizedString("bar", "ipsum");
+                var problem = new ProblemDetail(400)
+                {
+                    { "foo", new ExtensionValue() }
+                };
+                A.CallTo(() => inner.Create(exception)).Returns(problem);
+
+                /* Act */
+                var localizedProblem = sut.Create(exception);
+
+                /* Assert */
+                A.CallTo(() => localizer[null]).MustNotHaveHappened();
+                Assert.Equal("", localizedProblem["foo"]);
+            }
+
+
+            [Fact]
             public void StringExtension_TranslationCalled()
             {
                 /* Arrange */
@@ -201,6 +222,11 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
                     val => Assert.Equal("ipsum", val),
                     val => Assert.Equal("lorem", val));
             }
+        }
+
+        private sealed class ExtensionValue
+        {
+            public override string ToString() => null;
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/ProblemDetailOptionsTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/ProblemDetailOptionsTests.cs
@@ -3,44 +3,54 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
     using Xunit;
     using BusinessApp.WebApi.ProblemDetails;
     using System;
+    using FakeItEasy;
 
     public class ProblemDetailOptionsTests
     {
         public readonly ProblemDetailOptions sut;
 
+        public class Constructor : ProblemDetailOptionsTests
+        {
+            [Fact]
+            public void SetsType()
+            {
+                /* Arrange */
+                var type = typeof(string);
+
+                /* Act */
+                var sut = new ProblemDetailOptions(typeof(string), 0);
+
+                /* Assert */
+                Assert.Equal(type, sut.ProblemType);
+            }
+
+            [Fact]
+            public void SetsStatusCode()
+            {
+                /* Arrange */
+                var status = 2;
+
+                /* Act */
+                var sut = new ProblemDetailOptions(A.Dummy<Type>(), status);
+
+                /* Assert */
+                Assert.Equal(2, sut.StatusCode);
+            }
+        }
+
         public class ObjectEqualsOverride : ProblemDetailOptionsTests
         {
             [Fact]
-            public void NotAProblemDetailOptiontArgument_AreEqual()
+            public void NotAProblemDetailArgument_NotEqual()
             {
                 /* Arrange */
-                var sut = new ProblemDetailOptions();
+                var sut = new ProblemDetailOptions(A.Dummy<Type>(), 0);
 
                 /* Act */
                 bool equal = sut.Equals("foo");
 
                 /* Assert */
                 Assert.False(equal);
-            }
-
-            [Fact]
-            public void HaveSameProblemType_AreEqual()
-            {
-                /* Arrange */
-                var sut = new ProblemDetailOptions
-                {
-                    ProblemType = typeof(string)
-                };
-                var other = new ProblemDetailOptions
-                {
-                    ProblemType = typeof(string)
-                };
-
-                /* Act */
-                bool equal = sut.Equals(other);
-
-                /* Assert */
-                Assert.True(equal);
             }
 
             [Theory]
@@ -52,14 +62,8 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
                 bool expectEquals)
             {
                 /* Arrange */
-                var sut = new ProblemDetailOptions
-                {
-                    ProblemType = a
-                };
-                var other = new ProblemDetailOptions
-                {
-                    ProblemType = b
-                };
+                var sut = new ProblemDetailOptions(a, 0);
+                var other = new ProblemDetailOptions(b, 1);
 
                 /* Act */
                 bool equal = sut.Equals(other);

--- a/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
+++ b/CSharp/src/BusinessApp.WebApi/BootstrapOptions.cs
@@ -2,11 +2,19 @@ namespace BusinessApp.WebApi
 {
     using System.Collections.Generic;
     using System.Reflection;
+    using BusinessApp.Domain;
 
     public sealed class BootstrapOptions
     {
+        public BootstrapOptions(string connStr)
+        {
+            DbConnectionString = connStr
+                .NotEmpty()
+                .Expect("A data connection string is bootstrap to start this application");
+        }
+
         public string DbConnectionString { get; set; }
-        public string LogFilePath { get; set; }
-        public IEnumerable<Assembly> RegistrationAssemblies { get; set; }
+        public string? LogFilePath { get; set; }
+        public IEnumerable<Assembly> RegistrationAssemblies { get; init; } = new List<Assembly>();
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/BusinessApp.WebApi.csproj
+++ b/CSharp/src/BusinessApp.WebApi/BusinessApp.WebApi.csproj
@@ -12,6 +12,7 @@
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">0.0.1-local</Version>
     <VersionSuffix Condition=" '$(Configuration)' == 'Debug' ">dev</VersionSuffix>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/EnvelopeQueryResourceHandler.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.WebApi
     using System;
 
     public class EnvelopeQueryResourceHandler<T, R> : IHttpRequestHandler<T, IEnumerable<R>>
-        where T : IQuery
+        where T : notnull, IQuery
     {
         private readonly IRequestHandler<T, EnvelopeContract<R>> handler;
         private readonly ISerializer serializer;

--- a/CSharp/src/BusinessApp.WebApi/HateoasEventLink.cs
+++ b/CSharp/src/BusinessApp.WebApi/HateoasEventLink.cs
@@ -7,16 +7,16 @@ namespace BusinessApp.WebApi
     /// Hateoas links for <see cre="IDomainEvent" />
     /// </summary>
     /// <typeparam name="T">The request type that triggered the event</typeparam>
-    /// <typeparam name="R">The event type</typeparam>
+    /// <typeparam name="E">The event type</typeparam>
     public abstract class HateoasEventLink<T, E> : HateoasLink<T, IDomainEvent>
         where E : IDomainEvent
     {
         public HateoasEventLink(string rel)
             : base(rel)
-        {
-            RelativeLinkFactory = (r, e) => EventRelativeLinkFactory(r, (E)e);
-        }
+        { }
 
+        public override Func<T, IDomainEvent, string> RelativeLinkFactory
+            => (r, e) => EventRelativeLinkFactory(r, (E)e);
         protected abstract Func<T, E, string> EventRelativeLinkFactory { get; }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/HateoasLink.cs
+++ b/CSharp/src/BusinessApp.WebApi/HateoasLink.cs
@@ -13,6 +13,7 @@ namespace BusinessApp.WebApi
         protected HateoasLink(string rel)
         {
             Rel = rel.NotEmpty().Expect(rel);
+            RelativeLinkFactory = (t, r) => rel;
         }
 
         public HateoasLink(Func<T, R, string> relativeLinkFactory, string rel)
@@ -21,8 +22,8 @@ namespace BusinessApp.WebApi
             RelativeLinkFactory = relativeLinkFactory.NotNull().Expect(nameof(relativeLinkFactory));
         }
 
-        public Func<T, R, string> RelativeLinkFactory { get; protected set; }
+        public virtual Func<T, R, string> RelativeLinkFactory { get; }
         public string Rel { get; }
-        public string Title { get; init; }
+        public string? Title { get; init; }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/HttpRequestBodyAnalyzer.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpRequestBodyAnalyzer.cs
@@ -16,7 +16,7 @@
             this.analyzer = analyzer.NotNull().Expect(nameof(analyzer));
         }
 
-        public async Task HandleAsync<T, R>(HttpContext context)
+        public async Task HandleAsync<T, R>(HttpContext context) where T : notnull
         {
             var payloadType = await Analyze(context.Request);
 

--- a/CSharp/src/BusinessApp.WebApi/HttpRequestExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpRequestExtensions.cs
@@ -38,7 +38,7 @@ namespace BusinessApp.WebApi
         /// <summary>
         /// Deserializes the uri or body depending on the request method
         /// </summary>
-        public static async Task<T> DeserializeAsync<T>(this HttpRequest request,
+        public static async Task<T?> DeserializeAsync<T>(this HttpRequest request,
             ISerializer serializer,
             CancellationToken cancelToken)
         {
@@ -46,7 +46,7 @@ namespace BusinessApp.WebApi
             {
                 var bodyReader = request.BodyReader;
                 ReadResult readResult = await bodyReader.ReadAsync();
-                T model;
+                T? model;
 
                 try
                 {
@@ -76,7 +76,7 @@ namespace BusinessApp.WebApi
                     await bodyReader.CompleteAsync();
                 }
 
-                if (request.RouteValues.Count > 0)
+                if (model != null && request.RouteValues.Count > 0)
                 {
                     HttpRequestSerializationHelpers<T>.SetProperties(model, request.RouteValues);
                 }

--- a/CSharp/src/BusinessApp.WebApi/HttpRequestHandlerOfTR.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpRequestHandlerOfTR.cs
@@ -8,6 +8,7 @@ namespace BusinessApp.WebApi
     using System;
 
     public class HttpRequestHandler<T, R> : IHttpRequestHandler<T, R>
+        where T : notnull
     {
         private readonly IRequestHandler<T, R> handler;
         private readonly ISerializer serializer;

--- a/CSharp/src/BusinessApp.WebApi/HttpRequestLoggingDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpRequestLoggingDecorator.cs
@@ -19,7 +19,7 @@ namespace BusinessApp.WebApi
             this.logger = logger.NotNull().Expect(nameof(logger));
         }
 
-        public async Task HandleAsync<T, R>(HttpContext context)
+        public async Task HandleAsync<T, R>(HttpContext context) where T : notnull
         {
             try
             {
@@ -27,7 +27,7 @@ namespace BusinessApp.WebApi
             }
             catch (Exception exception)
             {
-                logger.Log(new LogEntry(LogSeverity.Error, exception.Message, exception));
+                logger.Log(LogEntry.FromException(exception));
 
                 throw;
             }

--- a/CSharp/src/BusinessApp.WebApi/HttpRequestLoggingDecoratorOfTR.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpRequestLoggingDecoratorOfTR.cs
@@ -7,9 +7,10 @@ namespace BusinessApp.WebApi
     using System.Threading;
 
     /// <summary>
-    /// Logs request errors and returns an error
+    /// Logs request errors and converts it to a <see cref="Result"/> type
     /// </summary>
     public class HttpRequestLoggingDecorator<T, R> : IHttpRequestHandler<T, R>
+        where T : notnull
     {
         private readonly IHttpRequestHandler<T, R> inner;
         private readonly ILogger logger;
@@ -49,7 +50,7 @@ namespace BusinessApp.WebApi
 
         private void Log(Exception exception)
         {
-            logger.Log(new LogEntry(LogSeverity.Error, exception.Message, exception));
+            logger.Log(LogEntry.FromException(exception));
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/HttpResponseDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpResponseDecorator.cs
@@ -9,6 +9,7 @@ namespace BusinessApp.WebApi
     using System.Threading;
 
     public class HttpResponseDecorator<T, R> : IHttpRequestHandler<T, R>
+        where T : notnull
     {
         private readonly IHttpRequestHandler<T, R> inner;
         private readonly IProblemDetailFactory problemFactory;

--- a/CSharp/src/BusinessApp.WebApi/HttpUserContext.cs
+++ b/CSharp/src/BusinessApp.WebApi/HttpUserContext.cs
@@ -16,8 +16,8 @@ namespace BusinessApp.WebApi
             this.httpContextAccessor = httpContextAccessor.NotNull().Expect(nameof(httpContextAccessor));
         }
 
-        public IIdentity Identity => Principal?.Identity;
+        public IIdentity? Identity => Principal?.Identity;
         public bool IsInRole(string role) => Principal?.IsInRole(role) ?? false;
-        private IPrincipal Principal => httpContextAccessor.HttpContext?.User;
+        private IPrincipal? Principal => httpContextAccessor.HttpContext?.User;
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/IHttpRequestHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/IHttpRequestHandler.cs
@@ -17,7 +17,7 @@ namespace BusinessApp.WebApi
         /// </summary>
         /// <typeparam name="T">The request type</typeparam>
         /// <typeparam name="R">The response type</typeparam>
-        Task HandleAsync<T, R>(HttpContext context);
+        Task HandleAsync<T, R>(HttpContext context) where T : notnull;
     }
 
     /// <summary>
@@ -26,6 +26,7 @@ namespace BusinessApp.WebApi
     /// <typeparam name="T">The request type</typeparam>
     /// <typeparam name="R">The response type</typeparam>
     public interface IHttpRequestHandler<T, R>
+        where T : notnull
     {
         Task<Result<HandlerContext<T, R>, Exception>> HandleAsync(
             HttpContext context, CancellationToken cancelToken);

--- a/CSharp/src/BusinessApp.WebApi/Json/JsonHttpDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/JsonHttpDecorator.cs
@@ -10,6 +10,7 @@
     /// Runs logic on the request/response for json requests
     /// </summary>
     public class JsonHttpDecorator<T, R> : IHttpRequestHandler<T, R>
+       where T : notnull
     {
         private readonly IHttpRequestHandler<T, R> inner;
 

--- a/CSharp/src/BusinessApp.WebApi/Json/JsonRegister.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/JsonRegister.cs
@@ -7,10 +7,8 @@ namespace BusinessApp.WebApi.Json
     public class JsonRegister : IBootstrapRegister
     {
         private static ProblemDetailOptions JsonProblemDetailOption =
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(JsonException), StatusCodes.Status400BadRequest)
             {
-                ProblemType = typeof(JsonException),
-                StatusCode = StatusCodes.Status400BadRequest,
                 MessageOverride = "Data is not in the correct format"
             };
         private readonly IBootstrapRegister inner;

--- a/CSharp/src/BusinessApp.WebApi/Json/NewtonsoftJsonExceptionDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/NewtonsoftJsonExceptionDecorator.cs
@@ -8,9 +8,10 @@ namespace BusinessApp.WebApi.Json
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Logs certains aspects of a request
+    /// Logs JSON exception and convert the response to a <see cref="Result"/> type
     /// </summary>
     public class NewtonsoftJsonExceptionDecorator<T, R> : IHttpRequestHandler<T, R>
+       where T : notnull
     {
         private readonly IHttpRequestHandler<T, R> inner;
         private readonly ILogger logger;
@@ -41,7 +42,7 @@ namespace BusinessApp.WebApi.Json
 
         private void Log(Exception exception)
         {
-            logger.Log(new LogEntry(LogSeverity.Error, exception.Message, exception));
+            logger.Log(LogEntry.FromException(exception));
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/Json/SystemJsonExceptionDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/SystemJsonExceptionDecorator.cs
@@ -8,9 +8,10 @@ namespace BusinessApp.WebApi.Json
     using System.Text.Json;
 
     /// <summary>
-    /// Logs certains aspects of a request
+    /// Logs JSON exception and convert the response to a <see cref="Result"/> type
     /// </summary>
     public class SystemJsonExceptionDecorator<T, R> : IHttpRequestHandler<T, R>
+       where T : notnull
     {
         private readonly IHttpRequestHandler<T, R> inner;
         private readonly ILogger logger;
@@ -41,7 +42,7 @@ namespace BusinessApp.WebApi.Json
 
         private void Log(Exception exception)
         {
-            logger.Log(new LogEntry(LogSeverity.Error, exception.Message, exception));
+            logger.Log(LogEntry.FromException(exception));
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/Bootstrap.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/Bootstrap.cs
@@ -2,6 +2,7 @@ namespace BusinessApp.WebApi.ProblemDetails
 {
     using System;
     using System.Collections.Generic;
+    using System.Data;
     using System.Security;
     using System.Threading.Tasks;
     using BusinessApp.App;
@@ -13,95 +14,61 @@ namespace BusinessApp.WebApi.ProblemDetails
     {
         public static HashSet<ProblemDetailOptions> KnownProblems = new HashSet<ProblemDetailOptions>
         {
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(ActivationException), StatusCodes.Status404NotFound)
             {
-                ProblemType = typeof(ActivationException),
-                StatusCode = StatusCodes.Status404NotFound,
                 MessageOverride =
                     "You tried to access an unknown part of the application. " +
                     "There no is business logic to handle your request. Please ensure " +
                     "you have the correct address."
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(EntityNotFoundException), StatusCodes.Status404NotFound)
             {
-                ProblemType = typeof(EntityNotFoundException),
-                StatusCode = StatusCodes.Status404NotFound,
                 MessageOverride =
                     "The resource you are looking for was not found at this location." +
                     "Ensure it exists and has not moved since your last request."
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(BadStateException), StatusCodes.Status400BadRequest),
+            new ProblemDetailOptions(typeof(FormatException), StatusCodes.Status400BadRequest)
             {
-                ProblemType = typeof(BadStateException),
-                StatusCode = StatusCodes.Status400BadRequest,
-            },
-            new ProblemDetailOptions
-            {
-                ProblemType = typeof(FormatException),
-                StatusCode = StatusCodes.Status400BadRequest,
                 MessageOverride = "One of your data fields was not in the correct format " +
                     "and was rejected. Please check your data before resubmtting"
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(InvalidOperationException), StatusCodes.Status400BadRequest)
             {
-                ProblemType = typeof(InvalidOperationException),
-                StatusCode = StatusCodes.Status400BadRequest,
                 MessageOverride =
                     "Your request was rejected because of bad data. Please review your " +
                     "request before resubmission."
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(TaskCanceledException), StatusCodes.Status400BadRequest)
             {
-                ProblemType = typeof(TaskCanceledException),
-                StatusCode = StatusCodes.Status400BadRequest,
                 MessageOverride =
                     "Your request has been cancelled. This is most likely due to a bad request. " +
                     "If more details are not provided check the state of your date and retry the request."
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(ModelValidationException), StatusCodes.Status400BadRequest),
+            new ProblemDetailOptions(typeof(SecurityException), StatusCodes.Status403Forbidden)
             {
-                ProblemType = typeof(ModelValidationException),
-                StatusCode = StatusCodes.Status400BadRequest
-            },
-            new ProblemDetailOptions
-            {
-                ProblemType = typeof(SecurityException),
-                StatusCode = StatusCodes.Status403Forbidden,
                 MessageOverride = "You have insufficient privileges to access this part of the application."
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(SecurityResourceException), StatusCodes.Status403Forbidden),
+            new ProblemDetailOptions(typeof(DBConcurrencyException), StatusCodes.Status409Conflict)
             {
-                ProblemType = typeof(SecurityResourceException),
-                StatusCode = StatusCodes.Status403Forbidden
-            },
-            new ProblemDetailOptions
-            {
-                ProblemType = typeof(SecurityResourceException),
-                StatusCode = StatusCodes.Status409Conflict,
                 MessageOverride = "You attempted to change data that has already been changed since " +
                     "you started work. Please refresh your application to ensure your data " +
                     "is still available."
 
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(NotImplementedException), StatusCodes.Status501NotImplemented)
             {
-                ProblemType = typeof(NotImplementedException),
-                StatusCode = StatusCodes.Status501NotImplemented,
                 MessageOverride = "Whoops! Your workflow is available, but we have not " +
                     "got around to implementing any of your business logic yet. Check back " +
                     "later."
             },
-            new ProblemDetailOptions
+            new ProblemDetailOptions(typeof(NotSupportedException), StatusCodes.Status501NotImplemented)
             {
-                ProblemType = typeof(NotSupportedException),
-                StatusCode = StatusCodes.Status501NotImplemented,
                 MessageOverride = "The application does not support this business workflow."
             },
-            new ProblemDetailOptions
-            {
-                ProblemType = typeof(CommunicationException),
-                StatusCode = StatusCodes.Status424FailedDependency,
-            },
+            new ProblemDetailOptions(typeof(CommunicationException), StatusCodes.Status424FailedDependency)
         };
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/CompositeProblemDetail.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/CompositeProblemDetail.cs
@@ -8,7 +8,7 @@ namespace BusinessApp.WebApi.ProblemDetails
 
     public class CompositeProblemDetail : ProblemDetail, IEnumerable<ProblemDetail>
     {
-        public CompositeProblemDetail(IEnumerable<ProblemDetail> problems, Uri type = null)
+        public CompositeProblemDetail(IEnumerable<ProblemDetail> problems, Uri? type = null)
             : base(StatusCodes.Status207MultiStatus, type)
         {
             Responses = problems.NotEmpty().Expect(nameof(problems));

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/IProblemDetailFactory.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/IProblemDetailFactory.cs
@@ -4,6 +4,6 @@ namespace BusinessApp.WebApi.ProblemDetails
 
     public interface IProblemDetailFactory
     {
-        ProblemDetail Create(Exception error = null);
+        ProblemDetail Create(Exception error);
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/LazyProblemDetailFactoryProxy.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/LazyProblemDetailFactoryProxy.cs
@@ -16,7 +16,7 @@ namespace BusinessApp.WebApi.ProblemDetails
             this.inner = inner.NotNull().Expect(nameof(inner));
         }
 
-        public ProblemDetail Create(Exception error = null)
+        public ProblemDetail Create(Exception error)
         {
             return this.inner.Value.Create(error);
         }

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/LocalizedProblemDetailFactory.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/LocalizedProblemDetailFactory.cs
@@ -44,6 +44,7 @@ namespace BusinessApp.WebApi.ProblemDetails
                 IDictionary d => TranslateExtension(d),
                 IEnumerable e when e is not string => TranslateExtension(e),
                 null => null,
+                object o when o.ToString() is null => null,
                 _ => localizer[value.ToString()!].Value,
             };
         }

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/ProblemDetail.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/ProblemDetail.cs
@@ -15,10 +15,10 @@
     public class ProblemDetail : IDictionary<string, object>
     {
         private readonly IDictionary<string, object> props = new Dictionary<string, object>();
-        private string detail;
-        private Uri instance;
+        private string? detail;
+        private Uri? instance;
 
-        public ProblemDetail(int status, Uri type = null)
+        public ProblemDetail(int status, Uri? type = null)
         {
             Type = type ?? new Uri("about:blank");
 
@@ -45,7 +45,7 @@
 
         public int StatusCode { get; }
         public string Title { get; }
-        public string Detail
+        public string? Detail
         {
             set
             {
@@ -63,7 +63,7 @@
             get => detail;
         }
         public Uri Type { get; }
-        public Uri Instance
+        public Uri? Instance
         {
             set
             {

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/ProblemDetailOptions.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/ProblemDetailOptions.cs
@@ -4,12 +4,18 @@ namespace BusinessApp.WebApi.ProblemDetails
 
     public class ProblemDetailOptions
     {
-        public Type ProblemType { get; set; }
-        public int StatusCode { get; set; }
-        public string AbsoluteType { get; set; }
-        public string MessageOverride { get; set; }
+        public ProblemDetailOptions(Type problemType, int statusCode)
+        {
+            ProblemType = problemType;
+            StatusCode = statusCode;
+        }
 
-        public override bool Equals(object obj)
+        public Type ProblemType { get; }
+        public int StatusCode { get; }
+        public string? AbsoluteType { get; init; }
+        public string? MessageOverride { get; set; }
+
+        public override bool Equals(object? obj)
         {
             if (obj is ProblemDetailOptions other)
             {

--- a/CSharp/src/BusinessApp.WebApi/Program.cs
+++ b/CSharp/src/BusinessApp.WebApi/Program.cs
@@ -26,10 +26,10 @@
             }
             catch (Exception ex)
             {
-                logger.Log(
-                    new LogEntry(LogSeverity.Critical,
-                        $"BusinessApp terminated unexpectedly",
-                        ex));
+                logger.Log(new LogEntry(LogSeverity.Critical, "BusinessApp terminated unexpectedly")
+                {
+                    Exception = ex
+                });
             }
         }
 

--- a/CSharp/src/BusinessApp.WebApi/RoutingBootstrapper.cs
+++ b/CSharp/src/BusinessApp.WebApi/RoutingBootstrapper.cs
@@ -75,7 +75,7 @@
 
         public int Id { get; set; }
 
-        public int ToInt32(IFormatProvider provider) => Id;
+        public int ToInt32(IFormatProvider? provider) => Id;
         public TypeCode GetTypeCode() => Id.GetTypeCode();
         public static implicit operator int (EntityId id) => id.Id;
     }
@@ -85,11 +85,16 @@
         public class Request : App.Query
         {
             public int Id { get; set; }
-            public override IEnumerable<string> Sort { get; set; }
+            public override IEnumerable<string> Sort { get; set; } = new List<string>();
         }
 
         public class Response
         {
+            public Response(EntityId? id = null)
+            {
+                Id = id ?? new EntityId(0);
+            }
+
             public EntityId Id { get; set; }
         }
 
@@ -101,8 +106,8 @@
             {
                 var response =  new []
                 {
-                    new Response() { Id = new EntityId(1) },
-                    new Response() { Id = new EntityId(2) },
+                    new Response(new EntityId(1)),
+                    new Response(new EntityId(2)),
                 }
                 .Where(r => r.Id.Id == request.Id);
 
@@ -113,14 +118,12 @@
             Task<Result<App.EnvelopeContract<Response>, Exception>> App.IRequestHandler<Request, App.EnvelopeContract<Response>>.HandleAsync(
                 Request request, CancellationToken cancelToken)
             {
-                var e =  Result.Ok(new App.EnvelopeContract<Response>
-                {
-                    Data = new [] { new Response() },
-                    Pagination = new App.Pagination
+                var e =  Result.Ok(new App.EnvelopeContract<Response>(
+                    new[] { new Response() },
+                    new App.Pagination
                     {
                         ItemCount = 1
-                    }
-                });
+                    }));
 
                 return Task.FromResult(e);
             }
@@ -132,7 +135,7 @@
         public class Body
         {
             public long LongerId { get; set; }
-            public EntityId Id { get; set; }
+            public EntityId? Id { get; set; }
         }
     }
 
@@ -140,18 +143,18 @@
     {
         public class Query
         {
-            public EntityId Id { get; set; }
+            public EntityId? Id { get; set; }
         }
 
         public class Response : IEventStream
         {
-            public IEnumerable<IDomainEvent> Events { get; set; }
+            public IEnumerable<IDomainEvent> Events { get; set; } = new List<IDomainEvent>();
 
         }
 
         public class Event : IDomainEvent
         {
-            public EntityId Id { get; set; }
+            public EntityId? Id { get; set; }
 
             public DateTimeOffset OccurredUtc { get; }
         }

--- a/CSharp/src/BusinessApp.WebApi/ServiceRegistrations/EFCoreRegister.cs
+++ b/CSharp/src/BusinessApp.WebApi/ServiceRegistrations/EFCoreRegister.cs
@@ -102,7 +102,7 @@ namespace BusinessApp.WebApi
         {
             public BusinessAppDbContext CreateDbContext(string[] args)
             {
-                var config = (IConfiguration)WebHost.CreateDefaultBuilder(args)
+                var config = (IConfiguration?)WebHost.CreateDefaultBuilder(args)
                     .ConfigureServices(sc => sc.AddSingleton(new Container()))
                     .ConfigureAppConfiguration(builder =>
                     {

--- a/CSharp/src/BusinessApp.WebApi/SimpleInjectorEventPublisher.cs
+++ b/CSharp/src/BusinessApp.WebApi/SimpleInjectorEventPublisher.cs
@@ -24,10 +24,10 @@ namespace BusinessApp.WebApi
         }
 
         public Task<EventResult> PublishAsync<T>(T @event, CancellationToken cancelToken)
-            where T : IDomainEvent
+            where T : notnull, IDomainEvent
         {
             var handler = (EventHandler)Activator.CreateInstance(
-                typeof(GenericEventHandler<>).MakeGenericType(typeof(T)));
+                typeof(GenericEventHandler<>).MakeGenericType(typeof(T)))!;
 
             return handler.HandleAsync(@event, cancelToken, container);
         }

--- a/CSharp/src/BusinessApp.WebApi/SimpleInjectorHttpRequestHandler.cs
+++ b/CSharp/src/BusinessApp.WebApi/SimpleInjectorHttpRequestHandler.cs
@@ -14,7 +14,7 @@ namespace BusinessApp.WebApi
             this.container = container.NotNull().Expect(nameof(container));
         }
 
-        public Task HandleAsync<T, R>(HttpContext context)
+        public Task HandleAsync<T, R>(HttpContext context) where T : notnull
         {
             return container.GetInstance<IHttpRequestHandler<T, R>>()
                 .HandleAsync(context, default);

--- a/CSharp/src/BusinessApp.WebApi/Startup.cs
+++ b/CSharp/src/BusinessApp.WebApi/Startup.cs
@@ -20,7 +20,7 @@
     public class Startup
     {
         private readonly Container container;
-        private readonly BootstrapOptions options = new BootstrapOptions();
+        private readonly BootstrapOptions options;
 
         public Startup(IConfiguration configuration, Container container)
         {
@@ -29,20 +29,23 @@
             container.Options.DefaultLifestyle = Lifestyle.Scoped;
             container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
 
-            options.LogFilePath = configuration.GetSection("Logging")
+            var loggingPath = configuration.GetSection("Logging")
                 .GetValue<string>("LogFilePath");
-            options.DbConnectionString =
 #if docker
-                configuration.GetConnectionString("docker");
+            var connStr = configuration.GetConnectionString("docker");
 #else
-                configuration.GetConnectionString("local");
+            var connStr = configuration.GetConnectionString("local");
 #endif
-            options.RegistrationAssemblies = new[]
+            options = new BootstrapOptions(connStr)
             {
-                typeof(App.IQuery).Assembly,
-                typeof(IQueryVisitor<>).Assembly,
-                typeof(IEventHandler<>).Assembly,
-                typeof(Startup).Assembly
+                LogFilePath = loggingPath,
+                RegistrationAssemblies = new[]
+                {
+                    typeof(App.IQuery).Assembly,
+                    typeof(IQueryVisitor<>).Assembly,
+                    typeof(IEventHandler<>).Assembly,
+                    typeof(Startup).Assembly
+                }
             };
         }
 

--- a/CSharp/src/BusinessApp.WebApi/WeblinkingHeaderEventRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/WeblinkingHeaderEventRequestDecorator.cs
@@ -13,6 +13,7 @@
     /// Decorator to add the web link headers for generate events
     /// </summary>
     public class WeblinkingHeaderEventRequestDecorator<T, R> : IHttpRequestHandler<T, R>
+       where T : notnull
        where R : IEventStream
     {
         private readonly IHttpRequestHandler<T, R> handler;

--- a/CSharp/src/BusinessApp.WebApi/WeblinkingHeaderRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/WeblinkingHeaderRequestDecorator.cs
@@ -12,6 +12,7 @@
     /// Decorator to add the web link headers for the particular response
     /// </summary>
     public class WeblinkingHeaderRequestDecorator<T, R> : IHttpRequestHandler<T, R>
+       where T : notnull
     {
         private readonly IHttpRequestHandler<T, R> handler;
         private readonly IEnumerable<HateoasLink<T, R>> links;


### PR DESCRIPTION
* Fix all classes that should have nullable checks
* Change `SecurityException` to DbConcurrency ProblemDetail. Had wrong
  error message and type associations
* Map string localizer without consumer to `Unit`
* Add `notnull` generic checks to most of application interfaces. Null
  checks should happen near webapi
* Leave a few warnings that need more investigation. Newtonsoft
  IDictionary convert should be removed. Not sure what it was doing. Can
  we set CausationId in ctor too?
* Change `ProblemDetailFactory` interface to a not null exception. The
  null use case is no longer in the app.
* fix incorrect `IHttpRequest<T,R>` order. Response should be after
  logging

fixes #5373, fixes #5389, fixes #4832