### PR TITLE
refactor(Analyzer): Inherit from IEquatable, add struct equality methods

### DIFF
--- a/CSharp/src/BusinessApp.Analyzers.IntegrationTest/BusinessApp.Analyzers.IntegrationTest.csproj
+++ b/CSharp/src/BusinessApp.Analyzers.IntegrationTest/BusinessApp.Analyzers.IntegrationTest.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>.</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>./generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <!-- if we do not run this it, build will throw an error saying the methods already exist -->

--- a/CSharp/src/BusinessApp.Analyzers.IntegrationTest/BusinessApp.Analyzers.IntegrationTest.csproj
+++ b/CSharp/src/BusinessApp.Analyzers.IntegrationTest/BusinessApp.Analyzers.IntegrationTest.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>./generated</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>.</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <!-- if we do not run this it, build will throw an error saying the methods already exist -->

--- a/CSharp/src/BusinessApp.Analyzers.IntegrationTest/IdAttributeTests.cs
+++ b/CSharp/src/BusinessApp.Analyzers.IntegrationTest/IdAttributeTests.cs
@@ -4,7 +4,7 @@ namespace BusinessApp.Analyzers.IntegrationTest
 {
     public class IdAttributeTests
     {
-        public class EqualsOverride : IdAttributeTests
+        public class IEquatableImpl : IdAttributeTests
         {
             [Theory]
             [InlineData("foo", true)]
@@ -21,6 +21,149 @@ namespace BusinessApp.Analyzers.IntegrationTest
 
                 /* Assert */
                 Assert.Equal(expectTrue, areEqual);
+            }
+        }
+
+        public class EqualsOverride : IdAttributeTests
+        {
+            [Theory]
+            [InlineData("foo", true)]
+            [InlineData("FOO", true)]
+            [InlineData("bar", false)]
+            public void WhenPropertiesEqual_TrueReturned(string b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new EntityStub { Id = "foo" };
+                object other = new EntityStub { Id = b };
+
+                /* Act */
+                var areEqual = sut.Equals(other);
+
+                /* Assert */
+                Assert.Equal(expectTrue, areEqual);
+            }
+        }
+
+        public class IComparableImpl : IdAttributeTests
+        {
+            [Theory]
+            [InlineData(1, 1)]
+            [InlineData(2, 0)]
+            [InlineData(3, -1)]
+            public void WhenCompared_AllPropsCompared(int b, int returnVal)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 2 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var compareValue = sut.CompareTo(other);
+
+                /* Assert */
+                Assert.Equal(returnVal, compareValue);
+            }
+        }
+
+        public class OperatorOverrides : IdAttributeTests
+        {
+            [Theory]
+            [InlineData(1, true)]
+            [InlineData(2, false)]
+            public void Equals_WhenPropertiesEqual_TrueReturned(int b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 1 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var areEqual = sut == other;
+
+                /* Assert */
+                Assert.Equal(expectTrue, areEqual);
+            }
+
+            [Theory]
+            [InlineData(1, false)]
+            [InlineData(2, true)]
+            public void NotEquals_WhenPropertiesNotEqual_TrueReturned(int b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 1 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var areEqual = sut != other;
+
+                /* Assert */
+                Assert.Equal(expectTrue, areEqual);
+            }
+
+            [Theory]
+            [InlineData(1, false)]
+            [InlineData(2, false)]
+            [InlineData(3, true)]
+            public void LessThan_WhenPropertyLessThan_TrueReturned(int b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 2 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var isTrue = sut < other;
+
+                /* Assert */
+                Assert.Equal(expectTrue, isTrue);
+            }
+
+            [Theory]
+            [InlineData(1, true)]
+            [InlineData(2, false)]
+            [InlineData(3, false)]
+            public void GreaterThan_WhenPropertyGreaterThan_TrueReturned(int b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 2 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var isTrue = sut > other;
+
+                /* Assert */
+                Assert.Equal(expectTrue, isTrue);
+            }
+
+            [Theory]
+            [InlineData(1, false)]
+            [InlineData(2, true)]
+            [InlineData(3, true)]
+            public void LessThanOrEqualTo_WhenPropertyLessThanOrEqualTo_TrueReturned(int b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 2 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var isTrue = sut <= other;
+
+                /* Assert */
+                Assert.Equal(expectTrue, isTrue);
+            }
+
+            [Theory]
+            [InlineData(1, true)]
+            [InlineData(2, true)]
+            [InlineData(3, false)]
+            public void GreaterThanOrEqualTo_WhenPropertyGreaterThanOrEqualTo_TrueReturned(int b, bool expectTrue)
+            {
+                /* Arrange */
+                var sut = new StructStub { Id = 2 };
+                var other = new StructStub { Id = b };
+
+                /* Act */
+                var isTrue = sut >= other;
+
+                /* Assert */
+                Assert.Equal(expectTrue, isTrue);
             }
         }
     }

--- a/CSharp/src/BusinessApp.Analyzers.IntegrationTest/Stubs.cs
+++ b/CSharp/src/BusinessApp.Analyzers.IntegrationTest/Stubs.cs
@@ -10,4 +10,13 @@ namespace BusinessApp.Analyzers.IntegrationTest
 #nullable restore
 
     }
+
+    public partial struct StructStub
+    {
+#nullable enable
+        [Id]
+        public int? Id { get; set; }
+#nullable restore
+
+    }
 }


### PR DESCRIPTION
* Add crummy spaghetti code to test struct/class equality. Can always
  refactor this to more modular code
* structs need `IComparable` and all operator overloads in addition to
  normal equality methods
* turn off IDE warnings because I would not know what the editor has