### PR TITLE
fix(efcore): Require discriminator value on generic `Metadata`

### DIFF
--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/MetadataEntityConfiguration.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/MetadataEntityConfiguration.cs
@@ -53,8 +53,11 @@ namespace BusinessApp.Infrastructure.Persistence
 
         public void Configure(EntityTypeBuilder<Metadata<T>> builder)
         {
-            _ = builder.HasDiscriminator(m => m.DataSetName)
+            _ = builder.HasDiscriminator<string>("MetadataType")
                 .HasValue(MetadataDiscriminatorValue);
+
+            _  = builder.Property("MetadataType")
+                .HasMaxLength(100);
         }
 
         public void Configure(EntityTypeBuilder<T> builder)

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/Migrations/20210416145222_AddMetadataTable.Designer.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/Migrations/20210416145222_AddMetadataTable.Designer.cs
@@ -49,8 +49,6 @@ namespace BusinessApp.Infrastructure.Persistence.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Metadata", "dbo");
-
-                    b.HasDiscriminator<string>("DataSetName");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.RequestMetadata", b =>

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/Migrations/BusinessAppDbContextModelSnapshot.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/Migrations/BusinessAppDbContextModelSnapshot.cs
@@ -47,8 +47,6 @@ namespace BusinessApp.Infrastructure.Persistence.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Metadata", "dbo");
-
-                    b.HasDiscriminator<string>("DataSetName");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.RequestMetadata", b =>

--- a/CSharp/src/BusinessApp.Test.Shared/BusinessAppTestDbContext.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/BusinessAppTestDbContext.cs
@@ -47,7 +47,7 @@ namespace BusinessApp.Test.Shared
                 .GetService(typeof(IConfiguration));
 
             var optionsBuilder = new DbContextOptionsBuilder<BusinessAppDbContext>();
-            var connection = config.GetConnectionString("Test");
+            var connection = config.GetConnectionString("DbTest");
 
             optionsBuilder.UseSqlServer(connection);
 

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.Designer.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.Designer.cs
@@ -60,6 +60,11 @@ namespace BusinessApp.Test.Shared.Migrations
                         .HasColumnType("varchar(100)")
                         .HasColumnName("DataSetName");
 
+                    b.Property<string>("MetadataType")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
                     b.Property<DateTimeOffset>("OccurredUtc")
                         .HasColumnType("datetimeoffset(0)")
                         .HasColumnName("OccurredUtc");
@@ -78,7 +83,7 @@ namespace BusinessApp.Test.Shared.Migrations
 
                     b.ToTable("Metadata", "dbo");
 
-                    b.HasDiscriminator<string>("DataSetName").HasValue("Metadata");
+                    b.HasDiscriminator<string>("MetadataType").HasValue("Metadata");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.RequestMetadata", b =>
@@ -228,7 +233,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 {
                     b.HasBaseType("BusinessApp.Infrastructure.Metadata");
 
-                    b.HasDiscriminator().HasValue("Metadata<Query>");
+                    b.HasDiscriminator().HasValue("BusinessApp.WebApi.Query");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>
@@ -242,7 +247,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 {
                     b.HasBaseType("BusinessApp.Infrastructure.Metadata");
 
-                    b.HasDiscriminator().HasValue("Metadata<Body>");
+                    b.HasDiscriminator().HasValue("BusinessApp.WebApi.Body");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.EventMetadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.cs
@@ -46,7 +46,8 @@ namespace BusinessApp.Test.Shared.Migrations
                     Username = table.Column<string>(type: "varchar(100)", nullable: false),
                     DataSetName = table.Column<string>(type: "varchar(100)", nullable: false),
                     TypeName = table.Column<string>(type: "varchar(100)", nullable: false),
-                    OccurredUtc = table.Column<DateTimeOffset>(type: "datetimeoffset(0)", nullable: false)
+                    OccurredUtc = table.Column<DateTimeOffset>(type: "datetimeoffset(0)", nullable: false),
+                    MetadataType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false)
                 },
                 constraints: table =>
                 {

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/BusinessAppTestDbContextModelSnapshot.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/BusinessAppTestDbContextModelSnapshot.cs
@@ -58,6 +58,11 @@ namespace BusinessApp.Test.Shared.Migrations
                         .HasColumnType("varchar(100)")
                         .HasColumnName("DataSetName");
 
+                    b.Property<string>("MetadataType")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
                     b.Property<DateTimeOffset>("OccurredUtc")
                         .HasColumnType("datetimeoffset(0)")
                         .HasColumnName("OccurredUtc");
@@ -76,7 +81,7 @@ namespace BusinessApp.Test.Shared.Migrations
 
                     b.ToTable("Metadata", "dbo");
 
-                    b.HasDiscriminator<string>("DataSetName").HasValue("Metadata");
+                    b.HasDiscriminator<string>("MetadataType").HasValue("Metadata");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.RequestMetadata", b =>
@@ -226,7 +231,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 {
                     b.HasBaseType("BusinessApp.Infrastructure.Metadata");
 
-                    b.HasDiscriminator().HasValue("Metadata<Query>");
+                    b.HasDiscriminator().HasValue("BusinessApp.WebApi.Query");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>
@@ -240,7 +245,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 {
                     b.HasBaseType("BusinessApp.Infrastructure.Metadata");
 
-                    b.HasDiscriminator().HasValue("Metadata<Body>");
+                    b.HasDiscriminator().HasValue("BusinessApp.WebApi.Body");
                 });
 
             modelBuilder.Entity("BusinessApp.Infrastructure.EventMetadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
@@ -117,7 +117,7 @@ namespace BusinessApp.WebApi.IntegrationTest
             // Given
             var notifier = A.Fake<ITestNotifier>();
             Container testContainer = null;
-            var client = factory.NewClient(container =>
+            var client = factory.NewClient((container, services) =>
             {
                 container.RegisterInstance(notifier);
 #if DEBUG

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/WebApplicationFactoryExtensions.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/WebApplicationFactoryExtensions.cs
@@ -21,14 +21,16 @@ namespace BusinessApp.WebApi.IntegrationTest
         private const string AuthenticationScheme = "FakeAuthenticationScheme";
 
         public static HttpClient NewClient<T>(this WebApplicationFactory<T> factory,
-            Action<Container> configuringServices = null)
+            Action<Container, IServiceCollection> configuringServices = null)
             where T : class
         {
             var startupContainer = new Container();
+
             startupContainer.Collection.Register<IServiceConfiguration>(new[]
             {
                 typeof(WebApplicationFactoryExtensions).Assembly
             });
+
             var client = factory
                 .WithWebHostBuilder(builder =>
                 {
@@ -43,7 +45,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                             .First(s => s.ServiceType == typeof(Container))
                             .ImplementationInstance;
 
-                        configuringServices?.Invoke(container);
+                        configuringServices?.Invoke(container, services);
 
                         _ = services.AddAuthentication(AuthenticationScheme)
                                 .AddScheme<AuthenticationSchemeOptions, FakeAuthenticationHandler>


### PR DESCRIPTION
* Require a value for the discriminator value in the entity configuration
or else it will default to the name of the class, which will not match
the `ToString()` value used at runtime for the discriminator column.
That does not work because EFCore uses a const value given at setup time
and places this in the `where` clause. Therefore, create a new column
for discriminator so if we query the non generic `Metadata` class, we
can still get the different types that were inserted by using the
`DataSetName` name.
* test: Add service collection to make test registration more flexable
* test: Fix migration connection string name